### PR TITLE
Fix for CDSVisualizationTest.verifyScatterPlotColorAxis

### DIFF
--- a/test/src/org/labkey/test/tests/CDSVisualizationTest.java
+++ b/test/src/org/labkey/test/tests/CDSVisualizationTest.java
@@ -680,7 +680,7 @@ public class CDSVisualizationTest extends BaseWebDriverTest implements PostgresO
 
     private String getPointProperty(String property, WebElement point)
     {
-        String titleAttribute = point.findElement(By.cssSelector("title")).getText();
+        String titleAttribute = point.getAttribute("title");
         String[] pointProperties = titleAttribute.split(",\n");
         Map<String, String> propertyMap = new HashMap<>();
 


### PR DESCRIPTION
- revert change to SVG point title attribute (see svn r36457)