### PR TITLE
Fixes for messaging plugin

### DIFF
--- a/webapp/Connector/src/controller/FilterStatus.js
+++ b/webapp/Connector/src/controller/FilterStatus.js
@@ -210,7 +210,7 @@ Ext.define('Connector.controller.FilterStatus', {
             filters: state.getFilters()
         });
 
-        state.on('filtercount', view.onFilterChange, view);
+        state.on('filtercount', view.onFilterCount, view);
         state.on('filterchange', view.onFilterChange, view);
         state.on('filterremove', view.onFilterRemove, view);
         state.on('selectionchange', view.onSelectionChange, view);

--- a/webapp/Connector/src/plugin/Messaging.js
+++ b/webapp/Connector/src/plugin/Messaging.js
@@ -24,7 +24,8 @@ Ext.define('Connector.plugin.Messaging', {
             hideMessage: this.hideMessage,
             showMessage: this.showMessage,
             sessionMessage: this.sessionMessage,
-            deferMessageTask: this.deferMessageTask
+            deferMessageTask: this.deferMessageTask,
+            resizeMessage: this.resizeMessage
         });
     },
 
@@ -75,6 +76,24 @@ Ext.define('Connector.plugin.Messaging', {
         }
     },
 
+    resizeMessage : function() {
+        if (this.msg && this.msg.isVisible()) {
+            var box = this.getBox();
+            this.msg.setPosition(
+                this.calculateX(this, box, this.msg.msg),
+                this.calculateY(this, box, this.msg.msg)
+            );
+        }
+    },
+
+    /**
+     * Displays a standard system message
+     * @param {string} msg The text to be displayed.
+     * @param {boolean} [force=false] Whether or not to force the message displaying.
+     * @param {boolean} keep [keep=false] False allows the message to fade after 8 seconds.
+     * @param {boolean} modal [modal=false] True if the message is a modal window, it will grey out the rest of the page.
+     * @returns {boolean} Returns true if the message was displayed, false otherwise.
+     */
     showMessage : function(msg, force, keep, modal) {
         var shown = false;
         if (this.showmsg || force) {

--- a/webapp/Connector/src/view/Chart.js
+++ b/webapp/Connector/src/view/Chart.js
@@ -23,13 +23,6 @@ Ext.define('Connector.view.Chart', {
 
     showPointsAsBin: false,
 
-    plugins : [{
-        ptype: 'messaging',
-        calculateY : function(cmp, box, msg) {
-            return box.y - 10;
-        }
-    }],
-
     newSelectors: false,
 
     constructor : function(config) {
@@ -103,7 +96,10 @@ Ext.define('Connector.view.Chart', {
 
         this.showmsg = true;
         this.addPlugin({
-            ptype: 'messaging'
+            ptype: 'messaging',
+            calculateY : function(cmp, box, msg) {
+                return box.y - 10;
+            }
         });
     },
 
@@ -383,6 +379,8 @@ Ext.define('Connector.view.Chart', {
                 el.setStyle('margin-left', 'auto');
             }
         }
+
+        this.resizeMessage();
 
         if (Ext.isFunction(this.highlightSelectedFn)) {
             this.highlightSelectedFn();
@@ -2691,7 +2689,6 @@ Ext.define('Connector.view.Chart', {
 
         }, me);
     },
-
 
     applyFiltersToMeasure : function (measures, ptids) {
 

--- a/webapp/Connector/src/view/FilterStatus.js
+++ b/webapp/Connector/src/view/FilterStatus.js
@@ -21,6 +21,19 @@ Ext.define('Connector.view.FilterStatus', {
         ];
 
         this.callParent();
+
+        this.attachInternalListeners();
+    },
+
+    attachInternalListeners : function() {
+
+        this.resizeTask = new Ext.util.DelayedTask(function() {
+            this.resizeMessage();
+        }, this);
+
+        Ext.EventManager.onWindowResize(function() {
+            this.resizeTask.delay(150);
+        }, this);
     },
 
     getFilterPanel : function() {

--- a/webapp/Connector/src/view/FilterStatus.js
+++ b/webapp/Connector/src/view/FilterStatus.js
@@ -62,8 +62,7 @@ Ext.define('Connector.view.FilterStatus', {
         return this.selectionpanel;
     },
 
-    onFilterChange : function(filters) {
-        this.hideMessage(true);
+    onFilterCount : function(filters) {
         if (this.filterpanel) {
             this.filterpanel.loadFilters(filters);
 
@@ -79,6 +78,12 @@ Ext.define('Connector.view.FilterStatus', {
                 clrBtn.show();
             }
         }
+    },
+
+    //23658 - Don't remove undo message when applying filter removal to plot.
+    onFilterChange : function(filters) {
+        this.hideMessage(true);
+        this.onFilterCount(filters)
     },
 
     onFilterRemove : function() {

--- a/webapp/Connector/src/view/Grid.js
+++ b/webapp/Connector/src/view/Grid.js
@@ -195,6 +195,7 @@ Ext.define('Connector.view.Grid', {
                     var size = this.getWidthHeight();
                     this.getGrid().setSize(size.width, size.height);
                     this.showAlignFooter(null, null, true);
+                    this.resizeMessage();
                 }
             }
         }, 50, this);

--- a/webapp/Connector/src/view/SingleAxisExplorer.js
+++ b/webapp/Connector/src/view/SingleAxisExplorer.js
@@ -95,7 +95,7 @@ Ext.define('Connector.view.SingleAxisExplorer', {
 
     initExplorerView : function() {
 
-        // Allows for scrollable Explorer view without comprimising Ext layout.
+        // Allows for scrollable Explorer view without compromising Ext layout.
         var resizeTask = new Ext.util.DelayedTask(function(p) {
             var id = 'single-axis-explorer';
             if (p) {
@@ -107,13 +107,7 @@ Ext.define('Connector.view.SingleAxisExplorer', {
             var container = Ext.get(id);
             container.setHeight(body.getBox().height);
 
-            if (this.saview && this.saview.msg) {
-                var sa = this.saview;
-                if (sa.msg.isVisible()) {
-                    var viewbox = sa.getBox();
-                    sa.msg.getEl().setLeft(Math.floor(viewbox.width/2 - Math.floor(this.getEl().getTextWidth(sa.msg.msg)/2)));
-                }
-            }
+            this.saview.resizeMessage();
         }, this);
 
         return Ext.create('Ext.Panel', {
@@ -259,13 +253,6 @@ Ext.define('Connector.view.SingleAxisExplorerView', {
 
     alias : 'widget.singleaxisview',
 
-    plugins : [{
-        ptype: 'messaging',
-        calculateY : function(cmp, box, msg) {
-            return box.y - 10;
-        }
-    }],
-
     emptyText : '<div class="saeempty">None of the selected subjects have data for this category.</div>',
 
     btnclick: false,
@@ -373,6 +360,13 @@ Ext.define('Connector.view.SingleAxisExplorerView', {
             endConfig: {
                 component: this,
                 events: ['hideload']
+            }
+        });
+
+        this.addPlugin({
+            ptype: 'messaging',
+            calculateY : function(cmp, box, msg) {
+                return box.y - 10;
             }
         });
     },


### PR DESCRIPTION
-Added a resizeMessage() function to the messaging plugin so that displayed messages can resize when the panel they belong to does as well. (Issue 23088)
-Fixed a bug where the undo messages on the chart would appear and immediately disappear. (Issue 23658) 
