### PR TITLE
Fix Biologics' and CDS' ability to close warning banners

### DIFF
--- a/webapp/Connector/src/view/Header.js
+++ b/webapp/Connector/src/view/Header.js
@@ -188,7 +188,7 @@ Ext.define('Connector.view.AnnouncementHeader', {
         if (btnEl){
             Ext4.EventManager.on(btnEl, 'click', function(){
                 LABKEY.Ajax.request({
-                    url : LABKEY.ActionURL.buildURL("core", "dismissCoreWarnings.api"),
+                    url : LABKEY.ActionURL.buildURL("core", "dismissWarnings.api"),
                     method : 'POST',
                     scope : this,
                     success : function (){


### PR DESCRIPTION
Alias DismissWarningsAction to DismissCoreWarningsAction to appease @glass

Correct CDS to use the new dismissal action name