### PR TITLE
Add consolidation script that was missed in 19.3

### DIFF
--- a/resources/schemas/dbscripts/postgresql/cds-19.20-19.30.sql
+++ b/resources/schemas/dbscripts/postgresql/cds-19.20-19.30.sql
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ALTER TABLE cds.import_document ADD COLUMN assay_identifier VARCHAR(250);
+ALTER TABLE cds.document ADD COLUMN assay_identifier VARCHAR(250);


### PR DESCRIPTION
Only purpose is to avoid confusion two years from now when we merge all the consolidated scripts into the bootstrap scripts and delete the incremental scripts.