### PR TITLE
Change optionalModules to modules as checkout location

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,10 @@ import org.labkey.gradle.util.BuildUtils
 
 dependencies
 {
-    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:optionalModules:dataintegration", depProjectConfig: "apiJarFile")
-    BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: ":server:optionalModules:dataintegration", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "study"), depProjectConfig: "published", depExtension: "module")
-    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:optionalModules:dataintegration", depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "published", depExtension: "module")
 }
 
 project.evaluationDependsOn(BuildUtils.getInternalProjectPath(project.gradle))


### PR DESCRIPTION
#### Rationale
Consolidate to server/modules as the preferred location for building module code 

#### Related Pull Requests
https://github.com/LabKey/trialServices/pull/17
https://github.com/LabKey/tnprc_billing/pull/55
https://github.com/LabKey/tnprc_ehr/pull/236
https://github.com/LabKey/premium/pull/187
https://github.com/LabKey/medImmuneFlow/pull/16
https://github.com/LabKey/MaxQuant/pull/24
https://github.com/LabKey/provenance/pull/21
TBD

#### Changes
Update README, build.gradle