### PR TITLE
appendNavTrail() to addNavTrail() migration

### DIFF
--- a/src/org/labkey/cds/CDSController.java
+++ b/src/org/labkey/cds/CDSController.java
@@ -171,9 +171,9 @@ public class CDSController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Dataspace Management");
+            root.addChild("Dataspace Management");
         }
     }
 
@@ -192,9 +192,8 @@ public class CDSController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -290,9 +289,8 @@ public class CDSController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -493,9 +491,8 @@ public class CDSController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -547,9 +544,8 @@ public class CDSController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -558,9 +554,8 @@ public class CDSController extends SpringActionController
     public class PermissionsReportExportAction extends SimpleViewAction<QueryForm>
     {
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
 
         @Override
@@ -845,9 +840,8 @@ public class CDSController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -985,9 +979,8 @@ public class CDSController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -1037,9 +1030,8 @@ public class CDSController extends SpringActionController
     public static class GetStudyDocumentAction extends SimpleViewAction<StudyDocumentForm>
     {
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
 
         @Override
@@ -1211,9 +1203,8 @@ public class CDSController extends SpringActionController
     public class ExportTourDefinitionsAction extends SimpleViewAction<QueryForm>
     {
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
 
         @Override

--- a/test/src/org/labkey/test/pages/cds/ColorAxisVariableSelector.java
+++ b/test/src/org/labkey/test/pages/cds/ColorAxisVariableSelector.java
@@ -39,6 +39,7 @@ public class ColorAxisVariableSelector extends DataspaceVariableSelector
         return "coloraxispicker";
     }
 
+    @Override
     public Locator.CssLocator window()
     {
         return Locator.css(".color-axis-selector");
@@ -91,6 +92,7 @@ public class ColorAxisVariableSelector extends DataspaceVariableSelector
         _test.sleep(750);
     }
 
+    @Override
     public void setScale(Scale scale)
     {
         throw new UnsupportedOperationException("No log scale for color variable");

--- a/test/src/org/labkey/test/pages/cds/DataGridVariableSelector.java
+++ b/test/src/org/labkey/test/pages/cds/DataGridVariableSelector.java
@@ -39,6 +39,7 @@ public class DataGridVariableSelector extends DataspaceVariableSelector
         return XPATH;
     }
 
+    @Override
     public Locator.CssLocator window()
     {
         return Locator.css("." + getPickerClass());

--- a/test/src/org/labkey/test/pages/cds/XAxisVariableSelector.java
+++ b/test/src/org/labkey/test/pages/cds/XAxisVariableSelector.java
@@ -41,6 +41,7 @@ public class XAxisVariableSelector extends DataspaceVariableSelector
         return "xaxispicker";
     }
 
+    @Override
     public Locator.CssLocator window()
     {
         return Locator.css("." + XPATHID);
@@ -112,6 +113,7 @@ public class XAxisVariableSelector extends DataspaceVariableSelector
         super.back(XPATHID);
     }
 
+    @Override
     public void setScale(Scale scale)
     {
         _test.waitForElementToBeVisible(Locator.xpath("//div[contains(@class, '" + XPATHID + "')]//div[text()='Scale:']/following-sibling::div"));

--- a/test/src/org/labkey/test/pages/cds/YAxisVariableSelector.java
+++ b/test/src/org/labkey/test/pages/cds/YAxisVariableSelector.java
@@ -37,6 +37,7 @@ public class YAxisVariableSelector extends DataspaceVariableSelector
         return "yaxispicker";
     }
 
+    @Override
     public Locator.CssLocator window()
     {
         return Locator.css("." + XPATHID);
@@ -99,6 +100,7 @@ public class YAxisVariableSelector extends DataspaceVariableSelector
         super.back(XPATHID);
     }
 
+    @Override
     public void setScale(Scale scale)
     {
         _test.waitForElementToBeVisible(Locator.xpath("//div[contains(@class, '" + XPATHID + "')]//div[text()='Scale:']/following-sibling::div"));

--- a/test/src/org/labkey/test/tests/cds/CDSFiltersTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSFiltersTest.java
@@ -43,6 +43,7 @@ public class CDSFiltersTest extends CDSReadOnlyTest
     private final CDSHelper cds = new CDSHelper(this);
     private final CDSAsserts _asserts = new CDSAsserts(this);
 
+    @Override
     @Before
     public void preTest()
     {

--- a/test/src/org/labkey/test/tests/cds/CDSGridTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSGridTest.java
@@ -54,6 +54,7 @@ public class CDSGridTest extends CDSReadOnlyTest
     private final CDSHelper cds = new CDSHelper(this);
     private final CDSAsserts _asserts = new CDSAsserts(this);
 
+    @Override
     @Before
     public void preTest()
     {

--- a/test/src/org/labkey/test/tests/cds/CDSGroupTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSGroupTest.java
@@ -53,6 +53,7 @@ public class CDSGroupTest extends CDSGroupBaseTest
 
     private boolean studyLabelUpdated = false;
 
+    @Override
     @Before
     public void preTest()
     {

--- a/test/src/org/labkey/test/tests/cds/CDSHelpCenterTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSHelpCenterTest.java
@@ -202,6 +202,7 @@ public class CDSHelpCenterTest extends CDSReadOnlyTest
         doShortWait();
     }
 
+    @Override
     @Before
     public void preTest()
     {

--- a/test/src/org/labkey/test/tests/cds/CDSLoginTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSLoginTest.java
@@ -33,6 +33,7 @@ import static org.labkey.test.pages.cds.CDSLoginPage.Locators.termsCheckbox;
 @Category({})
 public class CDSLoginTest extends CDSReadOnlyTest
 {
+    @Override
     @Before
     public void preTest()
     {

--- a/test/src/org/labkey/test/tests/cds/CDSMAbTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSMAbTest.java
@@ -56,6 +56,7 @@ public class CDSMAbTest extends CDSGroupBaseTest
 {
     private final CDSHelper cds = new CDSHelper(this);
 
+    @Override
     @Before
     public void preTest()
     {

--- a/test/src/org/labkey/test/tests/cds/CDSPlotTimeTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSPlotTimeTest.java
@@ -50,6 +50,7 @@ public class CDSPlotTimeTest extends CDSReadOnlyTest
     private final CDSPlot cdsPlot = new CDSPlot(this);
     private final CDSAsserts _asserts = new CDSAsserts(this);
 
+    @Override
     @Before
     public void preTest()
     {

--- a/test/src/org/labkey/test/tests/cds/CDSSubjectCountTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSSubjectCountTest.java
@@ -56,6 +56,7 @@ public class CDSSubjectCountTest extends CDSReadOnlyTest
     protected static final String BRUSHED_STROKE = "#00393A";
     protected static final String NORMAL_COLOR = "#000000";
 
+    @Override
     @Before
     public void preTest()
     {

--- a/test/src/org/labkey/test/tests/cds/CDSTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSTest.java
@@ -56,6 +56,7 @@ public class CDSTest extends CDSReadOnlyTest
     public static final String TOURS_WIKI_TITLE = "Take a tour";
     public static final String TOURS_WIKI_CONTENT = "<h3 id=\"take-tour-title-id\" class=\"tile-title\">Take a guided tour</h3>";
 
+    @Override
     @Before
     public void preTest()
     {

--- a/test/src/org/labkey/test/tests/cds/CDSVisualizationPlotTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSVisualizationPlotTest.java
@@ -37,6 +37,7 @@ public class CDSVisualizationPlotTest extends CDSReadOnlyTest
     private final CDSAsserts _asserts = new CDSAsserts(this);
     private final String XPATH_SUBJECT_COUNT = "//div[contains(@class, 'status-row')]//span[contains(@class, 'hl-status-label')][contains(text(), 'Subject')]/./following-sibling::span[contains(@class, ' hl-status-count ')][not(contains(@class, 'hideit'))]";
 
+    @Override
     @Before
     public void preTest()
     {

--- a/test/src/org/labkey/test/tests/cds/CDSVisualizationTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSVisualizationTest.java
@@ -86,6 +86,7 @@ public class CDSVisualizationTest extends CDSReadOnlyTest
 //        cvt.deleteParticipantGroups();
     }
 
+    @Override
     @Before
     public void preTest()
     {


### PR DESCRIPTION
#### Rationale
Adjust actions to implement `void addNavTrail()` instead of `NavTree appendNavTrail()`. Also, bulk annotate with @Override. See platform PR for more details.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1199