### PR TITLE
Secure Issue 40593: User not prompted for registration survey after password setting

### DIFF
--- a/src/org/labkey/cds/CDSController.java
+++ b/src/org/labkey/cds/CDSController.java
@@ -227,11 +227,26 @@ public class CDSController extends SpringActionController
     private static final String ANALYTICS_USER_GROUP = "Active CAVD Member";
 
     @RequiresNoPermission
+    public class UpdateNeedSurveyAction extends MutatingApiAction<Object>
+    {
+
+        @Override
+        public Object execute(Object o, BindException errors) throws Exception
+        {
+            CDSManager.get().setNeedSurvey(getUser(), true);
+
+            ApiSimpleResponse response  = new ApiSimpleResponse();
+            response.put("success", !errors.hasErrors());
+            return response;
+        }
+    }
+
+    @RequiresNoPermission
     @IgnoresTermsOfUse
     public class AppAction extends SimpleViewAction
     {
         @Override
-        public ModelAndView getView(Object o, BindException errors) throws Exception
+        public ModelAndView getView(Object o, BindException errors)
         {
             Container c = getContainer();
             StudyService sss = StudyService.get();
@@ -250,8 +265,6 @@ public class CDSController extends SpringActionController
             }
             else if (AuthenticationManager.isRegistrationEnabled() && (needSurvey || CDSManager.get().isNeedSurvey(getUser()) || getUser().getLastLogin() == null)) // on first log in, flag user as need survey
             {
-                if (needSurvey || getUser().getLastLogin() == null)
-                    CDSManager.get().setNeedSurvey(getUser(), true);
                 String surveyParam = getViewContext().getActionURL().getParameter("survey");
                 if (surveyParam == null || !"true".equals(surveyParam))
                 {

--- a/src/org/labkey/cds/CDSController.java
+++ b/src/org/labkey/cds/CDSController.java
@@ -226,7 +226,7 @@ public class CDSController extends SpringActionController
 
     private static final String ANALYTICS_USER_GROUP = "Active CAVD Member";
 
-    @RequiresNoPermission
+    @RequiresPermission(ReadPermission.class)
     public class UpdateNeedSurveyAction extends MutatingApiAction<Object>
     {
 

--- a/src/org/labkey/cds/CDSController.java
+++ b/src/org/labkey/cds/CDSController.java
@@ -251,7 +251,6 @@ public class CDSController extends SpringActionController
             Container c = getContainer();
             StudyService sss = StudyService.get();
             boolean hasStudy = null != sss && null != sss.getStudy(c);
-            boolean needSurvey = Boolean.parseBoolean(getViewContext().getActionURL().getParameter("NeedSurvey"));
 
             if (!c.isProject() || !hasStudy)
             {
@@ -259,18 +258,8 @@ public class CDSController extends SpringActionController
             }
 
             HttpView template;
-            if (getUser().isGuest())
+            if (getUser().isGuest() || (AuthenticationManager.isRegistrationEnabled() && (CDSManager.get().isNeedSurvey(getUser()))))// on first log in, flag user as need survey
             {
-                template = new FrontPageTemplate(defaultPageConfig());
-            }
-            else if (AuthenticationManager.isRegistrationEnabled() && (needSurvey || CDSManager.get().isNeedSurvey(getUser()) || getUser().getLastLogin() == null)) // on first log in, flag user as need survey
-            {
-                String surveyParam = getViewContext().getActionURL().getParameter("survey");
-                if (surveyParam == null || !"true".equals(surveyParam))
-                {
-                    ActionURL redirect = getViewContext().cloneActionURL().addParameter("survey", "true");
-                    throw new RedirectException(redirect);
-                }
                 template = new FrontPageTemplate(defaultPageConfig());
             }
             else

--- a/src/org/labkey/cds/CDSController.java
+++ b/src/org/labkey/cds/CDSController.java
@@ -236,6 +236,8 @@ public class CDSController extends SpringActionController
             Container c = getContainer();
             StudyService sss = StudyService.get();
             boolean hasStudy = null != sss && null != sss.getStudy(c);
+            boolean needSurvey = Boolean.parseBoolean(getViewContext().getActionURL().getParameter("NeedSurvey"));
+
             if (!c.isProject() || !hasStudy)
             {
                 throw new NotFoundException();
@@ -246,9 +248,9 @@ public class CDSController extends SpringActionController
             {
                 template = new FrontPageTemplate(defaultPageConfig());
             }
-            else if (AuthenticationManager.isRegistrationEnabled() && (CDSManager.get().isNeedSurvey(getUser()) || getUser().getLastLogin() == null)) // on first log in, flag user as need survey
+            else if (AuthenticationManager.isRegistrationEnabled() && (needSurvey || CDSManager.get().isNeedSurvey(getUser()) || getUser().getLastLogin() == null)) // on first log in, flag user as need survey
             {
-                if (getUser().getLastLogin() == null)
+                if (needSurvey || getUser().getLastLogin() == null)
                     CDSManager.get().setNeedSurvey(getUser(), true);
                 String surveyParam = getViewContext().getActionURL().getParameter("survey");
                 if (surveyParam == null || !"true".equals(surveyParam))

--- a/src/org/labkey/cds/CDSManager.java
+++ b/src/org/labkey/cds/CDSManager.java
@@ -309,12 +309,25 @@ public class CDSManager
 
     public boolean isNeedSurvey(User user)
     {
-        SimpleFilter filter = new SimpleFilter();
-        filter.addCondition(FieldKey.fromParts("UserId"), user.getUserId());
-        filter.addCondition(FieldKey.fromParts("NeedSurvey"), true);
+        String needSurveyProp = "NeedSurvey";
+        Domain domain = getSiteUserTableInfo(user).getDomain();
+        if (domain == null)
+            return false;
 
-        TableSelector selector = new TableSelector(getSiteUserTableInfo(user), Collections.singleton("NeedSurvey"), filter, null);
-        return selector.exists();
+        Map<String, DomainProperty> propsMap = new HashMap<>();
+        for (DomainProperty dp : domain.getProperties())
+            propsMap.put(dp.getName(), dp);
+
+        if (propsMap.containsKey(needSurveyProp))
+        {
+            Map<String, Object> properties = OntologyManager.getProperties(getUserTableContainer(), user.getEntityId());
+            String propertyUri = propsMap.get(needSurveyProp).getPropertyURI();
+            if(properties.containsKey(propertyUri))
+            {
+                return (boolean) properties.get(propertyUri);
+            }
+        }
+        return false;
     }
 
     public void setNeedSurvey(User user, boolean needSurvey) throws ValidEmail.InvalidEmailException, SQLException, BatchValidationException, InvalidKeyException, QueryUpdateServiceException, ValidationException

--- a/webapp/frontPage/js/modal.js
+++ b/webapp/frontPage/js/modal.js
@@ -413,7 +413,7 @@ define(['jquery', 'magnific', 'util'], function($, magnific, util) {
             }).success(function() {
               window.location = LABKEY.ActionURL.buildURL("cds", "app.view", null, {survey:true}); // set password should log user in automatically
             }).error(function(e) {
-              console.log('Unable to set NeedSurvey property to true');
+              console.error('Unable to set NeedSurvey property to true');
               window.location = LABKEY.ActionURL.buildURL("cds", "app.view");
             });
 

--- a/webapp/frontPage/js/modal.js
+++ b/webapp/frontPage/js/modal.js
@@ -411,7 +411,7 @@ define(['jquery', 'magnific', 'util'], function($, magnific, util) {
                 'X-LABKEY-CSRF': LABKEY.CSRF
               }
             }).success(function() {
-              window.location = LABKEY.ActionURL.buildURL("cds", "app.view", null, {NeedSurvey:true}); // set password should log user in automatically
+              window.location = LABKEY.ActionURL.buildURL("cds", "app.view", null, {survey:true}); // set password should log user in automatically
             }).error(function(e) {
               var errorMsg = 'Unable to set NeedSurvey property to true';
               createAccountError(e, errorMsg);

--- a/webapp/frontPage/js/modal.js
+++ b/webapp/frontPage/js/modal.js
@@ -415,6 +415,7 @@ define(['jquery', 'magnific', 'util'], function($, magnific, util) {
             }).error(function(e) {
               var errorMsg = 'Unable to set NeedSurvey property to true';
               createAccountError(e, errorMsg);
+              window.location = LABKEY.ActionURL.buildURL("cds", "app.view");
             });
 
           }).error(function(e) {

--- a/webapp/frontPage/js/modal.js
+++ b/webapp/frontPage/js/modal.js
@@ -413,8 +413,7 @@ define(['jquery', 'magnific', 'util'], function($, magnific, util) {
             }).success(function() {
               window.location = LABKEY.ActionURL.buildURL("cds", "app.view", null, {survey:true}); // set password should log user in automatically
             }).error(function(e) {
-              var errorMsg = 'Unable to set NeedSurvey property to true';
-              createAccountError(e, errorMsg);
+              console.log('Unable to set NeedSurvey property to true');
               window.location = LABKEY.ActionURL.buildURL("cds", "app.view");
             });
 

--- a/webapp/frontPage/js/modal.js
+++ b/webapp/frontPage/js/modal.js
@@ -395,7 +395,7 @@ define(['jquery', 'magnific', 'util'], function($, magnific, util) {
             'X-LABKEY-CSRF': LABKEY.CSRF
           }
         }).success(function() {
-            window.location = LABKEY.ActionURL.buildURL("cds", "app.view?"); // set password should log user in automatically
+            window.location = LABKEY.ActionURL.buildURL("cds", "app.view", null, {NeedSurvey:true}); // set password should log user in automatically
         }).error(function(e) {
           var errorMsg = 'Create account failed. ';
           if (e && e.responseJSON && e.responseJSON.errors && e.responseJSON.errors.length > 0) {

--- a/webapp/frontPage/js/modal.js
+++ b/webapp/frontPage/js/modal.js
@@ -372,6 +372,13 @@ define(['jquery', 'magnific', 'util'], function($, magnific, util) {
 
       });
 
+      function createAccountError(e, errorMsg) {
+        if (e && e.responseJSON && e.responseJSON.errors && e.responseJSON.errors.length > 0) {
+          errorMsg = errorMsg + e.responseJSON.errors[0].message;
+        }
+        $('.create-account-modal .notifications p').html(errorMsg);
+      }
+
       self.action('confirmcreateaccount', function($click) {
         var pw1 = document.getElementById('password3');
         var pw2 = document.getElementById('password4');
@@ -395,14 +402,25 @@ define(['jquery', 'magnific', 'util'], function($, magnific, util) {
             'X-LABKEY-CSRF': LABKEY.CSRF
           }
         }).success(function() {
-            window.location = LABKEY.ActionURL.buildURL("cds", "app.view", null, {NeedSurvey:true}); // set password should log user in automatically
-        }).error(function(e) {
-          var errorMsg = 'Create account failed. ';
-          if (e && e.responseJSON && e.responseJSON.errors && e.responseJSON.errors.length > 0) {
-            errorMsg = errorMsg + e.responseJSON.errors[0].message;
-          }
-          $('.create-account-modal .notifications p').html(errorMsg);
-        });
+
+            //sets NeedSurvey to true
+            $.ajax({
+              url: LABKEY.ActionURL.buildURL("cds", "updateNeedSurvey.api"),
+              method: 'POST',
+              data: {
+                'X-LABKEY-CSRF': LABKEY.CSRF
+              }
+            }).success(function() {
+              window.location = LABKEY.ActionURL.buildURL("cds", "app.view", null, {NeedSurvey:true}); // set password should log user in automatically
+            }).error(function(e) {
+              var errorMsg = 'Unable to set NeedSurvey property to true';
+              createAccountError(e, errorMsg);
+            });
+
+          }).error(function(e) {
+            var errorMsg = 'Create account failed. ';
+            createAccountError(e, errorMsg);
+          });
 
       });
 


### PR DESCRIPTION
#### Rationale
NeedSurvey property was determined using lastLogin being null, but it is no longer the case. Also, cds.appAction is not a mutating action so is unable to set the NeedSurvey value.

#### Changes
- Create a new MutatingApiAction that sets NeedSurvey value to true after newly registered user sets the password.