### PR TITLE
update CDS jquery version

### DIFF
--- a/src/org/labkey/cds/view/template/ConnectorTemplate.jsp
+++ b/src/org/labkey/cds/view/template/ConnectorTemplate.jsp
@@ -99,7 +99,7 @@
         }
     %>
 
-    <script type="text/javascript" src="<%=text(contextPath)%>/internal/jQuery/jquery-1.12.4.min.js"></script>
+    <script type="text/javascript" src="<%=text(contextPath)%>/internal/jQuery/jquery-3.5.1.min.js"></script>
     <script type="text/javascript" src="<%=text(contextPath)%>/hopscotch/js/hopscotch.min.js"></script>
 
     <script type="text/javascript" src="<%=text(sdkPath)%>/ext-all<%= text(devMode ? "-debug" : "") %>.js"></script>


### PR DESCRIPTION
#### Rationale
We recently made a platform change to update the version of jquery to 3.5.1. CDS doesn't rely on the 'normal' dependency mechanism and has explicit references to dependencies that need to be kept in sync.

#### Changes
- request the updated 3.5.3.min.js library that LabKey now serves up.