### PR TITLE
Fix for scrolling issue in Firefox, and addt'l log messages for treatment and assay links issue

### DIFF
--- a/src/org/labkey/cds/CDSController.java
+++ b/src/org/labkey/cds/CDSController.java
@@ -1054,12 +1054,18 @@ public class CDSController extends SpringActionController
 
             if (resource != null)
             {
+                LOG.info("Resource path: " + resource.getPath()); //TODO: Added for investigating Ticket 40760, to be removed.
+
                 File requestedFile = resource.getFile();
                 if (requestedFile == null || !requestedFile.canRead())
                 {
                     if (requestedFile != null)
                     {
                         LOG.info(requestedFile.getName() + " is readable: " + requestedFile.canRead());//TODO: Added for investigating Ticket 40760, to be removed.
+                    }
+                    else
+                    {
+                        LOG.info("Requested file is null."); //TODO: Added for investigating Ticket 40760, to be removed.
                     }
                     isValidLink = false;
                 }

--- a/webapp/Connector/src/app/view/AssayAntigen.js
+++ b/webapp/Connector/src/app/view/AssayAntigen.js
@@ -35,7 +35,9 @@ Ext.define('Connector.view.AssayAntigen', {
         if (this.learnViewConfig)
         {
             this.learnView = this.learnViewConfig.learnView;
-            this.learnView.getEl().removeCls('auto-scroll-y');
+            if (this.learnView.getEl().contains('auto-scroll-y')) {
+                this.learnView.getEl().removeCls('auto-scroll-y');
+            }
             this.tabId = this.learnViewConfig.tabId;
             this.tabDimension = this.learnViewConfig.tabDimension;
             this.tabParams = this.learnViewConfig.tabParams;

--- a/webapp/Connector/src/app/view/module/AssaySchemaMethod.js
+++ b/webapp/Connector/src/app/view/module/AssaySchemaMethod.js
@@ -18,7 +18,7 @@ Ext.define('Connector.view.module.AssaySchemaMethod', {
                     '<h3 id="assay_methods_title" class="listing_title">{method_title}</h3>',
                     '<tpl if="methods_assay_schema_link_valid">',
                         '<div class="schema-link">',
-                            '<a id="methods_assay_link" href= "' + LABKEY.contextPath + '{assay_schema_link}" target="_blank">Click for assay schema</a>',
+                            '<a id="methods_assay_link" href= "{assay_schema_link_1}" target="_blank">Click for assay schema</a>',
                         '</div>',
                     '</tpl>',
                      '{methods}',
@@ -35,6 +35,8 @@ Ext.define('Connector.view.module.AssaySchemaMethod', {
 
         var methodsAssaySchemaLinkIsValid = function (schema_link, result) {
             data['methods_assay_schema_link_valid'] = result;
+            data['assay_schema_link_1'] = Ext.isEmpty(LABKEY.contextPath) ? data['assay_schema_link'] : (LABKEY.contextPath + data['assay_schema_link']);
+            console.log("assay schema link path = " + data['assay_schema_link_1']); //TODO: Added for investigating Ticket 40760, to be removed.
             this.update(data);
         };
 

--- a/webapp/Connector/src/app/view/module/TreatmentSchemaGroup.js
+++ b/webapp/Connector/src/app/view/module/TreatmentSchemaGroup.js
@@ -18,7 +18,7 @@ Ext.define('Connector.view.module.TreatmentSchemaGroup', {
                     '<h3 id="treatment_groups_title" class="listing_title">{group_title}</h3>',
                         '<tpl if="treatment_schema_link_valid">',
                             '<div class="schema-link">',
-                                '<a id="groups_treatment_link" href= "' + LABKEY.contextPath + '{treatment_schema_link}" target="_blank">Click for treatment schema</a>',
+                                '<a id="groups_treatment_link" href= "{treatment_schema_link_1}" target="_blank">Click for treatment schema</a>',
                             '</div>',
                         '</tpl>',
                         '{groups}',
@@ -35,6 +35,8 @@ Ext.define('Connector.view.module.TreatmentSchemaGroup', {
 
         var treatmentSchemaLinkIsValid = function (schema_link, result) {
             data['treatment_schema_link_valid'] = result;
+            data['treatment_schema_link_1'] = Ext.isEmpty(LABKEY.contextPath) ? data['treatment_schema_link'] : (LABKEY.contextPath + data['treatment_schema_link']);
+            console.log("Treatment schema link path = " + data['treatment_schema_link_1']); //TODO: Added for investigating Ticket 40760, to be removed.
             this.update(data);
         };
 


### PR DESCRIPTION
#### Rationale
Ticket 40760: treatment and assay schemas - show link only when file exists - link not showing up on Staging server
Ticket 41299: Issues scrolling pages accessed via Learn in Firefox

#### Changes
- For Treatment and Assay schema links, conditionalize context path (even though Dataspace staging/production server doesn't have context path, our tests does), additional log messages for further troubleshooting.
- For Issues scrolling in Firefox - remove 'auto-scroll-y' only if it is present.