### PR TITLE
Update NAb and NAbMAb ETL queries to join on assay_identifier

### DIFF
--- a/resources/queries/cds/ds_nab.sql
+++ b/resources/queries/cds/ds_nab.sql
@@ -59,4 +59,4 @@ nab.titer_ID50,
 nab.titer_ID80,
 nab.slope
 
-FROM cds.import_nab nab left join cds.import_nabantigen na on na.cds_virus_id = nab.cds_virus_id
+FROM cds.import_nab nab left join cds.import_nabantigen na on na.cds_virus_id = nab.cds_virus_id AND na.assay_identifier = nab.assay_identifier

--- a/resources/queries/cds/ds_nabmab.sql
+++ b/resources/queries/cds/ds_nabmab.sql
@@ -66,4 +66,4 @@ SELECT
   dd.fit_error,
   dd.vaccine_matched
 
-FROM cds.import_NABMAb AS dd left join cds.import_nabantigen na on na.cds_virus_id = dd.cds_virus_id
+FROM cds.import_NABMAb AS dd left join cds.import_nabantigen na on na.cds_virus_id = dd.cds_virus_id AND na.assay_identifier = dd.assay_identifier


### PR DESCRIPTION
#### Rationale
NAbAntigen data has the same cds_virus_id for different assays, causing NAb and NAbMAb assays to have duplicate rows. Such duplication of rows in NAbMAb is causing downstream issues related to PK constraint violation during an ETL run for 'mabgridbase'.

#### Changes
Update NAb and NAbMAb ETL queries to join on assay_identifier (in addition to cds_virus_id) to avoid duplicate rows.