### PR TITLE
Support ticket 41378: saved group - change tooltip text to description

### DIFF
--- a/webapp/Connector/src/panel/GroupList.js
+++ b/webapp/Connector/src/panel/GroupList.js
@@ -64,7 +64,7 @@ Ext.define('Connector.view.GroupListView', {
         '<tpl for=".">',
             '{[this.renderGroupHeading(values, parent, xindex)]}',
             '<div class="grouprow">',
-                '<div title="{label:htmlEncode}" class="grouplabel">{label:this.groupLabel}</div>',
+                '<div title="{description:htmlEncode}" class="grouplabel">{label:this.groupLabel}</div>',
                 '<tpl if="this.plotter(containsPlot)">',
                     '<div class="groupicon"><img src="' + Connector.resourceContext.imgPath + '/plot.png"></div>',
                 '</tpl>',


### PR DESCRIPTION
#### Rationale
Ticket 41378: saved group - change tooltip text to description instead of group name

#### Changes
Replace title attribute with 'description' from 'label'.