### PR TITLE
Groups test failure fixes

### DIFF
--- a/test/src/org/labkey/test/util/cds/CDSHelper.java
+++ b/test/src/org/labkey/test/util/cds/CDSHelper.java
@@ -977,7 +977,7 @@ public class CDSHelper
             // Adding this test for the scenario of a test failure and this is called after the page has been removed.
             try
             {
-                isVisible = _test.isElementVisible(Locator.xpath("//div[contains(@class, 'grouplist-view')]//div[contains(@class, 'grouprow')]//div[contains(@title, '" + subName + "')]"));
+                isVisible = _test.isElementVisible(Locator.tagWithClass("div", "grouplabel").containing(subName));
             }
             catch (org.openqa.selenium.NoSuchElementException nse)
             {

--- a/test/src/org/labkey/test/util/cds/CDSHelper.java
+++ b/test/src/org/labkey/test/util/cds/CDSHelper.java
@@ -889,7 +889,7 @@ public class CDSHelper
 
     public void goToGroup(String groupName)
     {
-        Locator groupLabelLocator = Locator.xpath("//div[contains(@class, 'grouprow')]/div[contains(@class,'grouplabel')][@title='" + groupName + "']");
+        Locator groupLabelLocator = Locator.xpath("//div[contains(@class, 'grouprow')]/div[contains(@class,'grouplabel')]").withText(groupName);
 
         goToAppHome();
         _test.waitForElementToBeVisible(groupLabelLocator);


### PR DESCRIPTION
#### Rationale
Update Locators to use 'grouplabel' text instead of 'title' attribute value.