### PR TITLE
20.7 fb backport cds test fixes

### DIFF
--- a/test/src/org/labkey/test/pages/cds/DataspaceVariableSelector.java
+++ b/test/src/org/labkey/test/pages/cds/DataspaceVariableSelector.java
@@ -147,6 +147,7 @@ public abstract class DataspaceVariableSelector
     public void pickVariable(String variable)
     {
         Locator variableLock = window().append(" div.content-label").withText(variable);
+        _test.waitForElementToBeVisible(variableLock);
         _test.scrollIntoView(variableLock);
         _test.click(variableLock);
         _test.sleep(CDSHelper.CDS_WAIT_ANIMATION);
@@ -328,6 +329,7 @@ public abstract class DataspaceVariableSelector
         if (_test.isElementPresent(locDimField))
         {
             _test.longWait().until(LabKeyExpectedConditions.animationIsDone(locDimField));
+            _test.mouseOver(locDimField);
             _test.click(locDimField);
 
             // Let the drop down render.
@@ -336,9 +338,8 @@ public abstract class DataspaceVariableSelector
             for (String val : value)
                 _test.click(Locator.xpath(xpathDimDropDown + "//label[text()='" +val + "']"));
 
-            // Move the mouse so the drop down can close.
-            Actions builder = new Actions(_test.getDriver());
-            builder.moveToElement(locDimField.findElement(_test.getWrappedDriver()), 50, -50).build().perform();
+            // The drop down does not close after a selection is made, so need to close it by moving away from it.
+            _test.mouseOut();
 
         }
 
@@ -418,6 +419,8 @@ public abstract class DataspaceVariableSelector
 
                 if (_test.isElementPresent(locDimField))
                 {
+                    _test.mouseOver(locDimField);
+
                     _test.longWait().until(LabKeyExpectedConditions.animationIsDone(locDimField));
                     _test.click(locDimField);
 
@@ -436,7 +439,7 @@ public abstract class DataspaceVariableSelector
                         _test.click(Locator.xpath(xpathDimDropDown + "//label[text()='" +val + "']"));
 
                     // Move the mouse so the drop down can close.
-                    builder.moveToElement(locDimField.findElement(_test.getWrappedDriver()), 50, -50).build().perform();
+                    _test.mouseOut();
 
                 }
 

--- a/test/src/org/labkey/test/pages/cds/XAxisVariableSelector.java
+++ b/test/src/org/labkey/test/pages/cds/XAxisVariableSelector.java
@@ -17,10 +17,10 @@ package org.labkey.test.pages.cds;
 
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.util.LabKeyExpectedConditions;
 import org.labkey.test.util.cds.CDSHelper;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -116,13 +116,21 @@ public class XAxisVariableSelector extends DataspaceVariableSelector
     @Override
     public void setScale(Scale scale)
     {
-        _test.waitForElementToBeVisible(Locator.xpath("//div[contains(@class, '" + XPATHID + "')]//div[text()='Scale:']/following-sibling::div"));
-        _test.click(Locator.xpath("//div[contains(@class, '" + XPATHID + "')]//div[text()='Scale:']/following-sibling::div"));
-        _test.waitForElement(Locator.xpath("//div[contains(@class, '" + XPATHID + "-option-scale-dropdown')][not(contains(@style, 'display: none'))]//table[contains(@class, 'x-form-type-radio')]//tbody//tr//td//label[contains(text(), '" + scale.getScaleLabel() + "')]"), CDSHelper.CDS_WAIT * 2);
-        _test.click(Locator.xpath("//div[contains(@class, '" + XPATHID + "-option-scale-dropdown')][not(contains(@style, 'display: none'))]//table[contains(@class, 'x-form-type-radio')]//tbody//tr//td//label[contains(text(), '" + scale.getScaleLabel() + "')]"));
+        WebElement dropDownButton = Locator.xpath("//div[contains(@class, '" + XPATHID + "')]//div[text()='Scale:']/following-sibling::div").findWhenNeeded(_test.getDriver());
+        WebDriverWrapper.waitFor(dropDownButton::isDisplayed, "Dropdown button not visible.", 500);
+        dropDownButton.click();
+
+        WebElement dropDownOption = Locator
+                .xpath("//div[contains(@class, '" + XPATHID + "-option-scale-dropdown')][not(contains(@style, 'display: none'))]//table[contains(@class, 'x-form-type-radio')]//tbody//tr//td//label[contains(text(), '" + scale.getScaleLabel() + "')]")
+                .findWhenNeeded(_test.getDriver());
+        WebDriverWrapper.waitFor(dropDownOption::isDisplayed, String.format("Drop down option '%s' not displayed.'", scale.getScaleLabel()), 1_000);
+        dropDownOption.click();
 
         // Move the mouse so the drop down can close.
-        _test.mouseOver(Locator.tagWithClass("div", "main-title"));
+        _test.mouseOut();
+        WebDriverWrapper.waitFor(
+                ()->!Locator.tagWithClassContaining("div", XPATHID + "-option-scale-dropdown").findWhenNeeded(_test.getDriver()).isDisplayed(),
+                "Drop-down for the scale selector did not go away.", 500);
 
     }
 

--- a/test/src/org/labkey/test/pages/cds/XAxisVariableSelector.java
+++ b/test/src/org/labkey/test/pages/cds/XAxisVariableSelector.java
@@ -122,8 +122,7 @@ public class XAxisVariableSelector extends DataspaceVariableSelector
         _test.click(Locator.xpath("//div[contains(@class, '" + XPATHID + "-option-scale-dropdown')][not(contains(@style, 'display: none'))]//table[contains(@class, 'x-form-type-radio')]//tbody//tr//td//label[contains(text(), '" + scale.getScaleLabel() + "')]"));
 
         // Move the mouse so the drop down can close.
-        Actions builder = new Actions(_test.getDriver());
-        builder.moveToElement(Locator.xpath("//div[contains(@class, '" + XPATHID + "')]//div[text()='Scale:']").findElement(_test.getWrappedDriver()), 50, -50).build().perform();
+        _test.mouseOver(Locator.tagWithClass("div", "main-title"));
 
     }
 

--- a/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
+++ b/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
@@ -29,7 +29,6 @@ import org.labkey.test.pages.cds.LearnGrid;
 import org.labkey.test.util.cds.CDSAsserts;
 import org.labkey.test.util.cds.CDSHelper;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.File;
@@ -832,19 +831,19 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
 
         log("Verify Species");
         checker().verifyTrue("Species with the expected value 'HIV' is not visible.",
-                Locator.tagWithClass("div", "detail-gray-text").containing("HIV").findWhenNeeded(rowElement).isDisplayed());
+                Locator.tagWithClass("div", "detail-gray-text").containing("HIV").findElement(rowElement).isDisplayed());
 
         log("Verify Panels");
         checker().verifyTrue("Doesn't look like 'Diversity' is listed in the Panels.",
-                Locator.tagWithClass("div", "detail-text").childTag("p").containing("Diversity").findWhenNeeded(rowElement).isDisplayed());
+                Locator.tagWithClass("div", "detail-text").childTag("p").containing("Diversity").findElement(rowElement).isDisplayed());
 
         log("Verify Host Cell");
         checker().verifyTrue("Host cell with expected value '294T/18' is not visible.",
-                Locator.tagWithClass("div", "detail-gray-text").containing("294T/18").findWhenNeeded(rowElement).isDisplayed());
+                Locator.tagWithClass("div", "detail-gray-text").containing("294T/18").findElement(rowElement).isDisplayed());
 
         log("Verify Backbone");
         checker().verifyTrue("Backbone with expected value 'SG3 beta env 2' is not visible.",
-                Locator.tagWithClass("div", "detail-gray-text").withText("SG3 beta env 2").findWhenNeeded(rowElement).isDisplayed());
+                Locator.tagWithClass("div", "detail-gray-text").withText("SG3 beta env 2").findElement(rowElement).isDisplayed());
 
     }
 
@@ -865,26 +864,44 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
 
         log("Verify row for 'Ce2010_F5.LucR.T2A.ecto' virus");
 
+        Locator rowLocator = Locator.tagWithAttribute("tr", "data-recordid", "Ce2010_F5.LucR.T2A.ectoIMC Virus");
+
+        waitForElementToBeVisible(rowLocator);
+
+        WebElement rowElement = rowLocator.findElement(getDriver());
+
+        scrollIntoView(rowElement);
+
         log("Verify Virus short name");
-        waitForElement(Locator.xpath("//div").withClass("detail-description").child("h2").withText("Ce2010_F5.LucR.T2A.ecto"));
+        checker().verifyEquals("Virus short name not as expected.",
+                "Ce2010_F5.LucR.T2A.ecto",
+                Locator.tagWithClass("div", "detail-description").childTag("h2").findElement(rowElement).getText());
 
         log("Verify Virus long name");
-        assertElementPresent(Locator.xpath("//div").withClass("antigen-description").child("p").withText("Ce2010_F5.LucR.T2A.ecto, IMC, A3R5"));
+        checker().verifyEquals("Virus long name is incorrect.",
+                "Ce2010_F5.LucR.T2A.ecto,A3R5,full name",
+                Locator.tagWithClass("div", "antigen-description").childTag("p").findElements(rowElement).get(0).getText());
 
         log("Verify Virus other names");
-        assertElementPresent(Locator.xpath("//div").withClass("antigen-description").child("p").withText("Other names: Ce2010_F5.LucR.T2A.ecto, IMC, A3R5, ut massa"));
+        checker().verifyEquals("Virus other names is incorrect.",
+                "Other names: Ce2010_F5.LucR.T2A.ecto, IMC, A3R5, ut massa",
+                Locator.tagWithClass("div", "antigen-description").childTag("p").findElements(rowElement).get(1).getText());
 
         log("Verify Species");
-        assertElementPresent(Locator.xpath("//div").withClass("detail-gray-text").withText("HIV"));
+        checker().verifyTrue("Species with the expected value 'HIV' is not visible.",
+                Locator.tagWithClass("div", "detail-gray-text").containing("HIV").findWhenNeeded(rowElement).isDisplayed());
 
         log("Verify Panels");
-        assertElementPresent(Locator.xpath("//div").withClass("detail-text").child("p").withText("F Subtype"));
+        checker().verifyTrue("Doesn't look like 'F Subtype' is listed in the Panels.",
+                Locator.tagWithClass("div", "detail-text").childTag("p").containing("F Subtype").findElement(rowElement).isDisplayed());
 
         log("Verify Host Cell");
-        assertElementPresent(Locator.xpath("//div").withClass("detail-gray-text").withText("293T/17"));
+        checker().verifyTrue("Host cell with expected value '293T/17' is not visible.",
+                Locator.tagWithClass("div", "detail-gray-text").containing("293T/17").findElement(rowElement).isDisplayed());
 
         log("Verify Backbone");
-        assertElementPresent(Locator.xpath("//div").withClass("detail-gray-text").withText("SG3 beta env 4"));
+        checker().verifyTrue("Backbone with expected value 'SG3 beta env 4' is not visible.",
+                Locator.tagWithClass("div", "detail-gray-text").withText("SG3 beta env 4").findElement(rowElement).isDisplayed());
 
     }
 

--- a/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
+++ b/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
@@ -790,7 +790,7 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
         showAllExpandAndVerify(showAllListToggle, 2);
 
         List<WebElement> smallHasDataIcons =cds.hasDataDetailIconXPath("").findElements(getDriver());
-        assertTrue(smallHasDataIcons.size() == 10);
+        checker().verifyEquals("Icon size not as expected.", 10, smallHasDataIcons.size());
 
         verifyShowAllCollapse(showAllListToggle, 2);
 
@@ -812,23 +812,39 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
 
         log("Verify row for 'BJOX002000.03.2.delta624G.E625R.3-5' virus");
 
+        Locator rowLocator = Locator.tagWithAttribute("tr", "data-recordid", "BJOX002000.03.2.delta624G.E625R.3-5Env Pseudotype");
+
+        waitForElementToBeVisible(rowLocator);
+
+        WebElement rowElement = rowLocator.findElement(getDriver());
+
+        scrollIntoView(rowElement);
+
         log("Verify virus short name");
-        waitForElement(Locator.xpath("//div").withClass("detail-description").child("h2").withText("BJOX002000.03.2.delta624G.E625R.3-5"));
+        checker().verifyEquals("Virus short name not as expected.",
+                "BJOX002000.03.2.delta624G.E625R.3-5",
+                Locator.tagWithClass("div", "detail-description").childTag("h2").findElement(rowElement).getText());
 
         log("Verify Virus full name");
-        assertElementPresent(Locator.xpath("//div").withClass("antigen-description").child("p").withText("BJOX002000.03.2.delta624G.E625R.3-5, Env Pseudotype, TZM-bl, delta chain"));
+        checker().verifyEquals("Virus full name is incorrect.",
+                "BJOX002000.03.2.delta624G.E625R.3-5,TZM-bl,full name",
+                Locator.tagWithClass("div", "antigen-description").childTag("p").findElement(rowElement).getText());
 
         log("Verify Species");
-        assertElementPresent(Locator.xpath("//div").withClass("detail-gray-text").withText("HIV"));
+        checker().verifyTrue("Species with the expected value 'HIV' is not visible.",
+                Locator.tagWithClass("div", "detail-gray-text").containing("HIV").findWhenNeeded(rowElement).isDisplayed());
 
         log("Verify Panels");
-        assertElementPresent(Locator.xpath("//div").withClass("detail-text").child("p").withText("Diversity"));
+        checker().verifyTrue("Doesn't look like 'Diversity' is listed in the Panels.",
+                Locator.tagWithClass("div", "detail-text").childTag("p").containing("Diversity").findWhenNeeded(rowElement).isDisplayed());
 
         log("Verify Host Cell");
-        assertElementPresent(Locator.xpath("//div").withClass("detail-gray-text").withText("294T/18"));
+        checker().verifyTrue("Host cell with expected value '294T/18' is not visible.",
+                Locator.tagWithClass("div", "detail-gray-text").containing("294T/18").findWhenNeeded(rowElement).isDisplayed());
 
         log("Verify Backbone");
-        assertElementPresent(Locator.xpath("//div").withClass("detail-gray-text").withText("SG3 alpha env 1"));
+        checker().verifyTrue("Backbone with expected value 'SG3 beta env 2' is not visible.",
+                Locator.tagWithClass("div", "detail-gray-text").withText("SG3 beta env 2").findWhenNeeded(rowElement).isDisplayed());
 
     }
 

--- a/test/src/org/labkey/test/tests/cds/CDSVisualizationTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSVisualizationTest.java
@@ -1154,6 +1154,10 @@ public class CDSVisualizationTest extends CDSReadOnlyTest
         // This test will only validate that a "Filter" button shows up, but will not validate that the
         // range of the filter is as expected.
 
+        // I think that the JS errors we are seeing in TC runs are caused by test code and not product code.
+        // Going to pause the JS Error Checker for this test.
+        pauseJsErrorChecker();
+
         CDSHelper cds = new CDSHelper(this);
         int subjectCountBefore;
         String tempStr;
@@ -1281,6 +1285,9 @@ public class CDSVisualizationTest extends CDSReadOnlyTest
         cds.clearFilters();
         sleep(1000);
         _ext4Helper.waitForMaskToDisappear();
+
+        // Resume JS Error Checker.
+        resumeJsErrorChecker();
 
     }
 


### PR DESCRIPTION
#### Rationale
Back port some test fixes from develop to the 20.7 branch.

#### Related Pull Requests
* None

#### Changes
* Fixed some of the learn about test by changing the search scope for elements (narrowed it to the row).
* Improved reliability of dealing with pop-ups.
* Other fixes for timing issues (added better wait for element checks).
