### PR TITLE
Ticket 41685: Learn study pages integrated data subheader

### DIFF
--- a/resources/queries/cds/learn_mabStudies.sql
+++ b/resources/queries/cds/learn_mabStudies.sql
@@ -17,7 +17,7 @@
 -- mab as subject
 SELECT mabwithstudy.prot as prot, mabwithstudy.mab_mix_name_std, mabwithstudy.mab_label as mix_labels,
   studyassay.label, studyassay.has_data, studyassay.assay_status, 'MAb Characterization Studies' as study_type,
-  'Go to Monoclonal antibodies to visualize or export mAb data.' as subheader_instr
+  'Go to Monoclonal antibodies to visualize or export mAb data' as subheader_instr
 FROM cds.learn_mab_mix_forstudies mabwithstudy
 LEFT JOIN cds.learn_studiesforassays studyassay
   ON mabwithstudy.prot = studyassay.prot

--- a/resources/queries/cds/learn_mabStudies.sql
+++ b/resources/queries/cds/learn_mabStudies.sql
@@ -17,7 +17,7 @@
 -- mab as subject
 SELECT mabwithstudy.prot as prot, mabwithstudy.mab_mix_name_std, mabwithstudy.mab_label as mix_labels,
   studyassay.label, studyassay.has_data, studyassay.assay_status, 'MAb Characterization Studies' as study_type,
-  'Go to Monoclonal antibodies to view or export' as subheader_instr
+  'Go to Monoclonal antibodies to visualize or export mAb data.' as subheader_instr
 FROM cds.learn_mab_mix_forstudies mabwithstudy
 LEFT JOIN cds.learn_studiesforassays studyassay
   ON mabwithstudy.prot = studyassay.prot
@@ -28,7 +28,7 @@ UNION
 -- mab as product
 SELECT s.study_name as prot, mab.mab_mix_name_std, null as mix_labels,
        s.label, spm.has_data, studyassay.assay_status, 'MAb Administration Studies' as study_type,
-       'Go to Plot to view or Grid to export.  Additional non-integrated data files may be available for download. See study page.' as subheader_instr
+       'Visualize subject-level data in Plot or export from Grid. Additional data may be available. See study page.' as subheader_instr
 FROM cds.metadata.studyproductmap spm
           JOIN cds.product p ON (spm.product_id = p.product_id AND spm.projectContainer = p.container)
           JOIN cds.MabMixMetadata mab ON (mab.mab_mix_id = p.mab_mix_id AND mab.container = p.container)

--- a/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
+++ b/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
@@ -1107,11 +1107,19 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
     @Test
     public void testIntegratedDataInstructions()
     {
+        Locator plotLink = Locator.linkWithHref("#chart");
+        Locator gridLink = Locator.linkWithHref("#data");
+        Locator mabLink = Locator.linkWithHref("#mabgrid");
+
         String studyName = "QED 2";
         log("Verify instruction text on Learn About page for Studies - " + studyName);
         cds.viewLearnAboutPage("Studies");
         goToDetail(studyName, true);
-        assertTextPresent("Go to Plot to view or Grid to export");
+        assertTextPresent("Visualize subject-level data in");
+        assertElementPresent(plotLink);
+        assertElementPresent(gridLink);
+        assertTextPresent("For mAb data, go to");
+        assertElementPresent(mabLink);
 
         String assayName = CDSHelper.ASSAYS_FULL_TITLES[1]; //ICS
         log("Verify instruction text on Learn About page for Assays - " + assayName);
@@ -1123,16 +1131,22 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
         log("Verify instruction text on Learn About page for Products - " + productName);
         cds.viewLearnAboutPage("Products");
         goToDetail(productName, true);
-        assertTextPresent("Go to Plot to view or Grid to export. Additional non-integrated data files may be available for download. See study page.");
+        assertTextPresent("Visualize subject-level data in");
+        assertElementPresent(plotLink);
+        assertElementPresent(gridLink);
+        assertTextPresent("Additional data may be available. See study page.");
 
         String MAbName = "2F5";
         log("Verify sub-header instruction text on Learn About page for MAbs - " + MAbName);
         cds.viewLearnAboutPage("MAbs");
         goToDetail(MAbName, true);
-        String subHeaderCharacterizationInstr = "Go to Monoclonal antibodies to view or export";
-        String subHeaderAdministrationInstr = "Go to Plot to view or Grid to export.  Additional non-integrated data files may be available for download. See study page.";
-        assertTextPresent(subHeaderCharacterizationInstr);
-        assertTextPresent(subHeaderAdministrationInstr);
+
+        log("Verify sub-header instruction under MAb Characterization Studies");
+        assertTextPresent("to visualize or export mAb data.");
+        assertElementPresent(mabLink);
+        log("Verify sub-header instruction under MAb Administration Studies");
+        assertTextPresent("to visualize or export mAb data.");
+
 
         String publicationName = "Fong Y 2018 J Infect Dis";
         log("Verify instruction text on Learn About page for Publications - " + publicationName);

--- a/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
+++ b/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
@@ -1125,7 +1125,16 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
         log("Verify instruction text on Learn About page for Assays - " + assayName);
         cds.viewLearnAboutPage("Assays");
         goToDetail(assayName, true);
-        assertTextPresent("Go to Plot to view or Grid to export");
+        assertTextPresent("Visualize subject-level data in ");
+        assertElementPresent(plotLink);
+        assertElementPresent(gridLink);
+
+        String mabAssayName = CDSHelper.ASSAYS_FULL_TITLES[4]; //NAb MAb
+        log("Verify instruction text on Learn About page for NAB MAB assay - " + assayName);
+        cds.viewLearnAboutPage("Assays");
+        goToDetail(mabAssayName, true);
+        assertElementPresent(mabLink);
+        assertTextPresent("to visualize or export mAb data");
 
         String productName = "2F5";
         log("Verify instruction text on Learn About page for Products - " + productName);
@@ -1142,10 +1151,10 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
         goToDetail(MAbName, true);
 
         log("Verify sub-header instruction under MAb Characterization Studies");
-        assertTextPresent("to visualize or export mAb data.");
+        assertTextPresent("to visualize or export mAb data");
         assertElementPresent(mabLink);
         log("Verify sub-header instruction under MAb Administration Studies");
-        assertTextPresent("to visualize or export mAb data.");
+        assertTextPresent("to visualize or export mAb data");
 
 
         String publicationName = "Fong Y 2018 J Infect Dis";

--- a/webapp/Connector/cube.js
+++ b/webapp/Connector/cube.js
@@ -370,7 +370,7 @@ Ext4.define('Connector.cube.Configuration', {
                             title: 'Integrated data',
                             dataField: 'assays',
                             dataLink: 'Assay',
-                            instructions: 'Go to Plot to view or Grid to export'
+                            instructions: 'Visualize subject-level data in Plot or export from Grid. For mAb data, go to Monoclonal antibodies.'
                         }
                     }, {
                         type: 'studynonintegrateddata',
@@ -472,7 +472,7 @@ Ext4.define('Connector.cube.Configuration', {
                             title: 'Integrated data',
                             dataField: 'studies',
                             dataLink: 'Study',
-                            instructions: 'Go to Plot to view or Grid to export. Additional non-integrated data files may be available for download. See study page.'
+                            instructions: 'Visualize subject-level data in Plot or export from Grid. Additional data may be available. See study page.'
                         }
                     },{
                         type: 'productotherproducts',

--- a/webapp/Connector/cube.js
+++ b/webapp/Connector/cube.js
@@ -601,7 +601,8 @@ Ext4.define('Connector.cube.Configuration', {
                             title: 'Integrated data',
                             dataField: 'studies',
                             dataLink: 'Study',
-                            instructions: 'Go to Plot to view or Grid to export'
+                            instructions: 'Visualize subject-level data in Plot or export from Grid',
+                            nabMabInstructions: 'Go to Monoclonal antibodies to visualize or export mAb data'
                         }
                     }]]
                 },{

--- a/webapp/Connector/src/app/view/module/DataAvailabilityModule.js
+++ b/webapp/Connector/src/app/view/module/DataAvailabilityModule.js
@@ -37,6 +37,7 @@ Ext.define('Connector.view.module.DataAvailabilityModule', {
         this.update(this.data);
 
         this.toggleListTask = new Ext.util.DelayedTask(this.toggleList, this);
+        var assay_iden = this.data.model.data.assay_identifier;
 
         this.items = [{
             html: (new Ext.XTemplate('<tpl if="hasDetails">',
@@ -44,7 +45,7 @@ Ext.define('Connector.view.module.DataAvailabilityModule', {
                         Connector.constant.Templates.module.title,
                     '</p></div>',
                     '<p>',
-                    this.getInstructions(this.data.instructions),
+                    this.getInstructions(assay_iden && assay_iden.toLowerCase() === 'nab mab' ? this.data.nabMabInstructions : this.data.instructions),
                     '</p>',
                     '</br>',
                     '<table class="data-availability-header' + (this.data.hasGrouping ? ' data-availability-header-with-group' : '') + '">',
@@ -191,15 +192,15 @@ Ext.define('Connector.view.module.DataAvailabilityModule', {
         if (instructions) {
             if (instrWithHyperlink.indexOf("Monoclonal antibodies") >= 0) {
                 var splitInstr = instrWithHyperlink.split("Monoclonal antibodies");
-                instrWithHyperlink = splitInstr[0] + " <a href=\"#mabgrid\" target=\"_blank\">Monoclonal antibodies</a>" + splitInstr[1];
+                instrWithHyperlink = splitInstr[0] + "<a href=\"#mabgrid\">Monoclonal antibodies</a>" + splitInstr[1];
             }
             if (instrWithHyperlink.indexOf("Plot") >= 0) {
                 var splitPlot = instrWithHyperlink.split("Plot");
-                instrWithHyperlink = splitPlot[0] + " <a href=\"#chart\" target=\"_blank\">Plot</a> " + splitPlot[1];
+                instrWithHyperlink = splitPlot[0] + "<a href=\"#chart\">Plot</a>" + splitPlot[1];
             }
             if (instrWithHyperlink.indexOf("Grid") >= 0) {
                 var splitGrid = instrWithHyperlink.split("Grid");
-                instrWithHyperlink = splitGrid[0] + " <a href=\"#data\" target=\"_blank\">Grid</a>" + splitGrid[1];
+                instrWithHyperlink = splitGrid[0] + "<a href=\"#data\">Grid</a>" + splitGrid[1];
             }
         }
 
@@ -288,21 +289,6 @@ Ext.define('Connector.view.module.DataAvailabilityModule', {
                                     getInstructions: function(key)
                                     {
                                         return me.getInstructions(me.data.groupSubHeaderInstr[key]);
-                                        //
-                                        // if (instrWithHyperlink.indexOf("Monoclonal antibodies") >= 0) {
-                                        //     var splitInstr = instrWithHyperlink.split("Monoclonal antibodies");
-                                        //     instrWithHyperlink = splitInstr[0] + " <a href=\"#mabgrid\" target=\"_blank\">Monoclonal antibodies</a> " + splitInstr[1];
-                                        // }
-                                        // if (instrWithHyperlink.indexOf("Plot") >= 0) {
-                                        //     var splitPlot = instrWithHyperlink.split("Plot");
-                                        //     instrWithHyperlink = splitPlot[0] + " <a href=\"#chart\" target=\"_blank\">Plot</a> " + splitPlot[1];
-                                        // }
-                                        // if (instrWithHyperlink.indexOf("Grid") >= 0) {
-                                        //     var splitGrid = instrWithHyperlink.split("Grid");
-                                        //     instrWithHyperlink = splitGrid[0] + " <a href=\"#data\" target=\"_blank\">Grid</a>" + splitGrid[1];
-                                        // }
-                                        //
-                                        // return instrWithHyperlink;
                                     }
                                 })
                     }

--- a/webapp/Connector/src/app/view/module/DataAvailabilityModule.js
+++ b/webapp/Connector/src/app/view/module/DataAvailabilityModule.js
@@ -44,7 +44,7 @@ Ext.define('Connector.view.module.DataAvailabilityModule', {
                         Connector.constant.Templates.module.title,
                     '</p></div>',
                     '<p>',
-                        this.data.instructions,
+                    this.getInstructions(this.data.instructions),
                     '</p>',
                     '</br>',
                     '<table class="data-availability-header' + (this.data.hasGrouping ? ' data-availability-header-with-group' : '') + '">',
@@ -186,6 +186,26 @@ Ext.define('Connector.view.module.DataAvailabilityModule', {
         this.callParent();
     },
 
+    getInstructions: function (instructions) {
+        var instrWithHyperlink = instructions;
+        if (instructions) {
+            if (instrWithHyperlink.indexOf("Monoclonal antibodies") >= 0) {
+                var splitInstr = instrWithHyperlink.split("Monoclonal antibodies");
+                instrWithHyperlink = splitInstr[0] + " <a href=\"#mabgrid\" target=\"_blank\">Monoclonal antibodies</a>" + splitInstr[1];
+            }
+            if (instrWithHyperlink.indexOf("Plot") >= 0) {
+                var splitPlot = instrWithHyperlink.split("Plot");
+                instrWithHyperlink = splitPlot[0] + " <a href=\"#chart\" target=\"_blank\">Plot</a> " + splitPlot[1];
+            }
+            if (instrWithHyperlink.indexOf("Grid") >= 0) {
+                var splitGrid = instrWithHyperlink.split("Grid");
+                instrWithHyperlink = splitGrid[0] + " <a href=\"#data\" target=\"_blank\">Grid</a>" + splitGrid[1];
+            }
+        }
+
+        return instrWithHyperlink;
+    },
+
     toggleList: function(event, grpName) {
         var data = this.data;
         var dataView = this.items.items[1].getView();
@@ -267,7 +287,22 @@ Ext.define('Connector.view.module.DataAvailabilityModule', {
                                 {
                                     getInstructions: function(key)
                                     {
-                                        return me.data.groupSubHeaderInstr[key];
+                                        return me.getInstructions(me.data.groupSubHeaderInstr[key]);
+                                        //
+                                        // if (instrWithHyperlink.indexOf("Monoclonal antibodies") >= 0) {
+                                        //     var splitInstr = instrWithHyperlink.split("Monoclonal antibodies");
+                                        //     instrWithHyperlink = splitInstr[0] + " <a href=\"#mabgrid\" target=\"_blank\">Monoclonal antibodies</a> " + splitInstr[1];
+                                        // }
+                                        // if (instrWithHyperlink.indexOf("Plot") >= 0) {
+                                        //     var splitPlot = instrWithHyperlink.split("Plot");
+                                        //     instrWithHyperlink = splitPlot[0] + " <a href=\"#chart\" target=\"_blank\">Plot</a> " + splitPlot[1];
+                                        // }
+                                        // if (instrWithHyperlink.indexOf("Grid") >= 0) {
+                                        //     var splitGrid = instrWithHyperlink.split("Grid");
+                                        //     instrWithHyperlink = splitGrid[0] + " <a href=\"#data\" target=\"_blank\">Grid</a>" + splitGrid[1];
+                                        // }
+                                        //
+                                        // return instrWithHyperlink;
                                     }
                                 })
                     }


### PR DESCRIPTION
#### Rationale
Ticket 41685: Learn study pages integrated data subheader

#### Changes
- Modify subheaders for Integrated Data section for Study, MAb, and Products.
- Modify subheaders for Integrated Data section for Assays - conditional on NABMAB vs others.
- Add hyperlinks to 'Plot', 'Grid', and 'Monoclonal antibodies' in the subheader text.