### PR TITLE
Revert hyperlink additions to subheader text containing 'Plot', 'Grid', and 'Monoclonal antibodies'

### DIFF
--- a/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
+++ b/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
@@ -1131,24 +1131,24 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
         cds.viewLearnAboutPage("Studies");
         goToDetail(studyName, true);
         assertTextPresent("Visualize subject-level data in");
-        assertElementPresent(plotLink);
-        assertElementPresent(gridLink);
+//        assertElementPresent(plotLink);
+//        assertElementPresent(gridLink);
         assertTextPresent("For mAb data, go to");
-        assertElementPresent(mabLink);
+//        assertElementPresent(mabLink);
 
         String assayName = CDSHelper.ASSAYS_FULL_TITLES[1]; //ICS
         log("Verify instruction text on Learn About page for Assays - " + assayName);
         cds.viewLearnAboutPage("Assays");
         goToDetail(assayName, true);
         assertTextPresent("Visualize subject-level data in ");
-        assertElementPresent(plotLink);
-        assertElementPresent(gridLink);
+//        assertElementPresent(plotLink);
+//        assertElementPresent(gridLink);
 
         String mabAssayName = CDSHelper.ASSAYS_FULL_TITLES[4]; //NAb MAb
         log("Verify instruction text on Learn About page for NAB MAB assay - " + assayName);
         cds.viewLearnAboutPage("Assays");
         goToDetail(mabAssayName, true);
-        assertElementPresent(mabLink);
+//        assertElementPresent(mabLink);
         assertTextPresent("to visualize or export mAb data");
 
         String productName = "2F5";
@@ -1156,8 +1156,8 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
         cds.viewLearnAboutPage("Products");
         goToDetail(productName, true);
         assertTextPresent("Visualize subject-level data in");
-        assertElementPresent(plotLink);
-        assertElementPresent(gridLink);
+//        assertElementPresent(plotLink);
+//        assertElementPresent(gridLink);
         assertTextPresent("Additional data may be available. See study page.");
 
         String MAbName = "2F5";
@@ -1167,7 +1167,7 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
 
         log("Verify sub-header instruction under MAb Characterization Studies");
         assertTextPresent("to visualize or export mAb data");
-        assertElementPresent(mabLink);
+//        assertElementPresent(mabLink);
         log("Verify sub-header instruction under MAb Administration Studies");
         assertTextPresent("to visualize or export mAb data");
 

--- a/webapp/Connector/src/app/view/module/DataAvailabilityModule.js
+++ b/webapp/Connector/src/app/view/module/DataAvailabilityModule.js
@@ -188,21 +188,26 @@ Ext.define('Connector.view.module.DataAvailabilityModule', {
     },
 
     getInstructions: function (instructions) {
+
+
         var instrWithHyperlink = instructions;
-        if (instructions) {
-            if (instrWithHyperlink.indexOf("Monoclonal antibodies") >= 0) {
-                var splitInstr = instrWithHyperlink.split("Monoclonal antibodies");
-                instrWithHyperlink = splitInstr[0] + "<a href=\"#mabgrid\">Monoclonal antibodies</a>" + splitInstr[1];
-            }
-            if (instrWithHyperlink.indexOf("Plot") >= 0) {
-                var splitPlot = instrWithHyperlink.split("Plot");
-                instrWithHyperlink = splitPlot[0] + "<a href=\"#chart\">Plot</a>" + splitPlot[1];
-            }
-            if (instrWithHyperlink.indexOf("Grid") >= 0) {
-                var splitGrid = instrWithHyperlink.split("Grid");
-                instrWithHyperlink = splitGrid[0] + "<a href=\"#data\">Grid</a>" + splitGrid[1];
-            }
-        }
+
+        // Commenting out below code for now, adding hyperlinks to subheader text has introduced a regression with tooltips.
+        // See Dataspace tickets:  41685 & 42000. Will have to re-implement hyperlink addition as part of ticket 42000
+        // if (instructions) {
+        //     if (instrWithHyperlink.indexOf("Monoclonal antibodies") >= 0) {
+        //         var splitInstr = instrWithHyperlink.split("Monoclonal antibodies");
+        //         instrWithHyperlink = splitInstr[0] + "<a href=\"#mabgrid\">Monoclonal antibodies</a>" + splitInstr[1];
+        //     }
+        //     if (instrWithHyperlink.indexOf("Plot") >= 0) {
+        //         var splitPlot = instrWithHyperlink.split("Plot");
+        //         instrWithHyperlink = splitPlot[0] + "<a href=\"#chart\">Plot</a>" + splitPlot[1];
+        //     }
+        //     if (instrWithHyperlink.indexOf("Grid") >= 0) {
+        //         var splitGrid = instrWithHyperlink.split("Grid");
+        //         instrWithHyperlink = splitGrid[0] + "<a href=\"#data\">Grid</a>" + splitGrid[1];
+        //     }
+        // }
 
         return instrWithHyperlink;
     },


### PR DESCRIPTION
#### Rationale
Ticket 41685: Learn study pages integrated data subheader:
Hyperlinks to the sub-header text containing 'Plot', 'Grid', and 'Monoclonal antibodies' were added as part of updates mentioned in this ticket. However, it introduced a regression around the tooltip display for the first data item in the grid. So reverting the change for now, to be re-implemented differently.

#### Changes
- Commented out the hyperlink changes