### PR TITLE
41986: Switch to using @labkey/api

### DIFF
--- a/src/org/labkey/cds/view/template/ConnectorTemplate.jsp
+++ b/src/org/labkey/cds/view/template/ConnectorTemplate.jsp
@@ -106,6 +106,7 @@
 
         // Client API Dependencies
         "/clientapi/labkey-api-js-core.min.js",
+        "/clientapi/dom/Utils.js",
         "/clientapi/dom/Webpart.js",
 
         "/clientapi/ext4/Util.js",

--- a/src/org/labkey/cds/view/template/ConnectorTemplate.jsp
+++ b/src/org/labkey/cds/view/template/ConnectorTemplate.jsp
@@ -105,16 +105,7 @@
         srcPath + "/ext-patches.js",
 
         // Client API Dependencies
-        "/clientapi/core/Ajax.js",
-        "/clientapi/core/Utils.js",
-        "/clientapi/dom/Utils.js",
-        "/clientapi/core/ActionURL.js",
-        "/clientapi/core/Filter.js",
-        "/clientapi/core/FieldKey.js",
-        "/clientapi/core/Query.js",
-        "/clientapi/core/Visualization.js",
-        "/clientapi/core/ParticipantGroup.js",
-        "/clientapi/core/Security.js",
+        "/clientapi/labkey-api-js-core.min.js",
         "/clientapi/dom/Webpart.js",
 
         "/clientapi/ext4/Util.js",

--- a/src/org/labkey/cds/view/template/FrontPage.jsp
+++ b/src/org/labkey/cds/view/template/FrontPage.jsp
@@ -55,9 +55,7 @@
     <script data-main="<%=getContextPath()%>/frontpage/js/config" src="<%=getWebappURL("/frontpage/components/requirejs/require.js")%>"></script>
 
     <%--<!-- Client API Dependencies -->--%>
-    <%=getScriptTag("/clientapi/core/Utils.js")%>
-    <%=getScriptTag("/clientapi/core/ActionURL.js")%>
-    <%=getScriptTag("/clientapi/core/Ajax.js")%>
+    <%=getScriptTag("/clientapi/labkey-api-js-core.min.js")%>
     <%=getScriptTag("/frontpage/components/jquery/dist/jquery.min.js")%>
     <script type="text/javascript">
         reloadRegisterPage = function() {


### PR DESCRIPTION
#### Rationale
With issue 41986 we fully switched over to using `@labkey/api`. This updates CDS to pull down the correct resources as the former implementation was removed with https://github.com/LabKey/platform/pull/1760.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1760

#### Changes
* Switch `/clientapi/core` references to reference `/clientapi/labkey-api-js-core.min.js`
