### PR TITLE
Feature Request 39434: Unwanted hyperlinks showing on headers

### DIFF
--- a/webapp/Connector/src/app/view/module/StudyResources.js
+++ b/webapp/Connector/src/app/view/module/StudyResources.js
@@ -43,7 +43,7 @@ Ext.define('Connector.view.module.StudyResources', {
             '</tpl>',
             '<tpl if="specimen_repository_label">',
                 '<div class="item-row">',
-                    'View research <a href="http://www.specimenrepository.org/RepositorySite/search/replaySearch?study={specimen_repository_label}" target="_blank">specimens in repository <img src="' + LABKEY.contextPath + '/Connector/images/outsidelink.png' + '"/><br/>',
+                    'View research <a href="http://www.specimenrepository.org/RepositorySite/search/replaySearch?study={specimen_repository_label}" target="_blank">specimens in repository <img src="' + LABKEY.contextPath + '/Connector/images/outsidelink.png' + '"/></a><br/>',
                 '</div>',
             '</tpl>',
         '</tpl>'


### PR DESCRIPTION
#### Rationale
Feature Request 39434: Add link to curated groups and Learn-reports on study pages.
Hyperlinks showing up on 'Interactive reports', 'Related Studies', 'Integrated Data', 'Non Integrated Data' headers.

#### Changes
* Add missing /a tag on "View research specimens in repository"
