### PR TITLE
CDS test fixs

### DIFF
--- a/test/src/org/labkey/test/tests/cds/CDSSubjectCountTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSSubjectCountTest.java
@@ -72,6 +72,9 @@ public class CDSSubjectCountTest extends CDSReadOnlyTest
         //TODO add back (and improve already exists test) when verifySavedGroupPlot is implemented.
 //        CDSVisualizationTest cvt = (CDSVisualizationTest)getCurrentTest();
 //        cvt.createParticipantGroups();
+
+        CDSSubjectCountTest currentTest = (CDSSubjectCountTest) getCurrentTest();
+        currentTest.cds.initModuleProperties(true);
     }
 
     @AfterClass
@@ -80,6 +83,9 @@ public class CDSSubjectCountTest extends CDSReadOnlyTest
         //TODO add back (and improve already exists test) when verifySavedGroupPlot is implemented.
 //        CDSVisualizationTest cvt = (CDSVisualizationTest)getCurrentTest();
 //        cvt.deleteParticipantGroups();
+
+        CDSSubjectCountTest currentTest = (CDSSubjectCountTest) getCurrentTest();
+        currentTest.cds.initModuleProperties(false);
     }
 
     @Override

--- a/test/src/org/labkey/test/tests/cds/CDSVisualizationPlotTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSVisualizationPlotTest.java
@@ -1,6 +1,8 @@
 package org.labkey.test.tests.cds;
 
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
@@ -45,6 +47,20 @@ public class CDSVisualizationPlotTest extends CDSReadOnlyTest
         cds.ensureNoFilter();
         cds.ensureNoSelection();
         getDriver().manage().window().setSize(CDSHelper.idealWindowSize);
+    }
+
+    @BeforeClass
+    public static void setShowHiddenVariables()
+    {
+        CDSVisualizationPlotTest currentTest = (CDSVisualizationPlotTest) getCurrentTest();
+        currentTest.cds.initModuleProperties(true); //set ShowHiddenVariables property to true
+    }
+
+    @AfterClass
+    public static void resetShowHiddenVariables()
+    {
+        CDSVisualizationPlotTest currentTest = (CDSVisualizationPlotTest) getCurrentTest();
+        currentTest.cds.initModuleProperties(false); // reset ShowHiddenVariables property back to false
     }
 
     @Override

--- a/test/src/org/labkey/test/tests/cds/CDSVisualizationTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSVisualizationTest.java
@@ -114,6 +114,20 @@ public class CDSVisualizationTest extends CDSReadOnlyTest
         return new Timeout(60, TimeUnit.MINUTES);
     }
 
+    @BeforeClass
+    public static void setShowHiddenVariables()
+    {
+        CDSVisualizationTest currentTest = (CDSVisualizationTest) getCurrentTest();
+        currentTest.cds.initModuleProperties(true); //set ShowHiddenVariables property to true
+    }
+
+    @AfterClass
+    public static void resetShowHiddenVariables()
+    {
+        CDSVisualizationTest currentTest = (CDSVisualizationTest) getCurrentTest();
+        currentTest.cds.initModuleProperties(false); // reset ShowHiddenVariables property back to false
+    }
+
     @Test
     public void verifyGutterPlotBasic()
     {


### PR DESCRIPTION
#### Rationale
Test fix for missing value in x-axis and y-axis failure. Enabling the showHiddenVariable experimental flag.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
1. test/src/org/labkey/test/tests/cds/CDSSubjectCountTest.java updated BeforeClass and AfterClass methods to enable and disable variable resp.
2. test/src/org/labkey/test/tests/cds/CDSVisualizationPlotTest.java added  BeforeClass and AfterClass methods to enable and disable variable resp.
