### PR TITLE
Add CuratedGroups.js to production lib.

### DIFF
--- a/webapp/Connector/extapp.lib.xml
+++ b/webapp/Connector/extapp.lib.xml
@@ -212,6 +212,7 @@
         <script path="Connector/src/app/view/module/StudyMabs.js"/>
         <script path="Connector/src/app/view/module/VariableList.js"/>
         <script path="Connector/src/app/view/module/InteractiveReports.js"/>
+        <script path="Connector/src/app/view/module/CuratedGroups.js"/>
 
         <script path="Connector/src/Application.js"/>
 


### PR DESCRIPTION
#### Rationale
Feature Request 39434: Add link to curated groups and Learn-reports on study pages
Curated Groups section not showing on production, instead it shows light gray line.

#### Changes
* Add CuratedGroups.js lib for production.