### PR TITLE
42807: Links to study page need to prompt user for login rather than take users to the front page

### DIFF
--- a/webapp/frontPage/js/application.js
+++ b/webapp/frontPage/js/application.js
@@ -73,7 +73,8 @@ require(['jquery', 'scroll', 'modal', 'util'], function( $, scroll, modal, util)
     initializeModals: function() {
       modal.initialize({
         name: 'signin-modal',
-        query_param_regex: /login=true|returnUrl=/i
+        query_param_regex: /login=true|returnUrl=/i,
+        show_for_page_nav: true       // render modal if there is a page route on the url
       });
 
       modal.initialize({

--- a/webapp/frontPage/js/modal.js
+++ b/webapp/frontPage/js/modal.js
@@ -585,6 +585,11 @@ define(['jquery', 'magnific', 'util'], function($, magnific, util) {
       var queryParamRegex = self.options.query_param_regex;
       var showPopup = location.search.match(queryParamRegex);
 
+      // issue 42807 links which reference app pages should automatically show the login & redirect
+      var showForPageNav = self.options.show_for_page_nav;
+      if (!showPopup && showForPageNav)
+        showPopup = location.hash;
+
       var loginRegex = /login=true|returnUrl=/i;
       if (queryParamRegex.source.toString() !== loginRegex.source.toString()) {
         // if login popup is already open, skip opening other matches


### PR DESCRIPTION
#### Rationale
Currently, if a guest clicks on a link like : https://dataspace.cavd.org/cds/CAVD/app.view#learn/learn/Study/vtn505?q=HVTN%20505 they will be redirected to the public front page. Dataspace would like the experience changed so that the login dialog is rendered and if/and after the user logs in they will be redirected to the app page on the URL.

#### Related Ticket
- https://www.labkey.org/Dataspace/Feature%20Requests/issues-details.view?issueId=42807

#### Changes
Modify the modal initialization on the front page to allow configured modals to show if there is a hash value. There is no validation of the hash route and the login modal is the only one which allow this.