### PR TITLE
Integrated Data subheader links tooltips

### DIFF
--- a/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
+++ b/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
@@ -1179,24 +1179,24 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
         cds.viewLearnAboutPage("Studies");
         goToDetail(studyName, true);
         assertTextPresent("Visualize subject-level data in");
-//        assertElementPresent(plotLink);
-//        assertElementPresent(gridLink);
+        assertElementPresent(plotLink);
+        assertElementPresent(gridLink);
         assertTextPresent("For mAb data, go to");
-//        assertElementPresent(mabLink);
+        assertElementPresent(mabLink);
 
         String assayName = CDSHelper.ASSAYS_FULL_TITLES[1]; //ICS
         log("Verify instruction text on Learn About page for Assays - " + assayName);
         cds.viewLearnAboutPage("Assays");
         goToDetail(assayName, true);
         assertTextPresent("Visualize subject-level data in ");
-//        assertElementPresent(plotLink);
-//        assertElementPresent(gridLink);
+        assertElementPresent(plotLink);
+        assertElementPresent(gridLink);
 
         String mabAssayName = CDSHelper.ASSAYS_FULL_TITLES[4]; //NAb MAb
         log("Verify instruction text on Learn About page for NAB MAB assay - " + assayName);
         cds.viewLearnAboutPage("Assays");
         goToDetail(mabAssayName, true);
-//        assertElementPresent(mabLink);
+        assertElementPresent(mabLink);
         assertTextPresent("to visualize or export mAb data");
 
         String productName = "2F5";
@@ -1204,8 +1204,8 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
         cds.viewLearnAboutPage("Products");
         goToDetail(productName, true);
         assertTextPresent("Visualize subject-level data in");
-//        assertElementPresent(plotLink);
-//        assertElementPresent(gridLink);
+        assertElementPresent(plotLink);
+        assertElementPresent(gridLink);
         assertTextPresent("Additional data may be available. See study page.");
 
         String MAbName = "2F5";
@@ -1215,7 +1215,7 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
 
         log("Verify sub-header instruction under MAb Characterization Studies");
         assertTextPresent("to visualize or export mAb data");
-//        assertElementPresent(mabLink);
+        assertElementPresent(mabLink);
         log("Verify sub-header instruction under MAb Administration Studies");
         assertTextPresent("to visualize or export mAb data");
 

--- a/webapp/Connector/src/app/view/module/DataAvailabilityModule.js
+++ b/webapp/Connector/src/app/view/module/DataAvailabilityModule.js
@@ -90,7 +90,7 @@ Ext.define('Connector.view.module.DataAvailabilityModule', {
 
             listeners : {
                 'itemmouseenter' : function(view, record, item, index, evt) {
-                    var dataLink = Ext.get(Ext.query("a", item)[0]) || Ext.get(Ext.query("span", item)[0]),
+                    var dataLink = Ext.get(Ext.query("a:not(.instruction)", item)[0]) || Ext.get(Ext.query("span", item)[0]),
                             id = Ext.id();
 
                     if (record.data.data_status && dataLink) {
@@ -145,7 +145,7 @@ Ext.define('Connector.view.module.DataAvailabilityModule', {
                 },
 
                 'itemmouseleave' : function(view, record, item) {
-                    var dataLink = Ext.get(Ext.query("a", item)[0]) || Ext.get(Ext.query("span", item)[0]);
+                    var dataLink = Ext.get(Ext.query("a:not(.instruction)", item)[0]) || Ext.get(Ext.query("span", item)[0]);
                     if (dataLink) {
                         dataLink.un('mouseenter', this.showDataStatusTooltip, this);
                         dataLink.un('mouseleave', this.hideDataStatusTooltip, this);
@@ -194,20 +194,20 @@ Ext.define('Connector.view.module.DataAvailabilityModule', {
 
         // Commenting out below code for now, adding hyperlinks to subheader text has introduced a regression with tooltips.
         // See Dataspace tickets:  41685 & 42000. Will have to re-implement hyperlink addition as part of ticket 42000
-        // if (instructions) {
-        //     if (instrWithHyperlink.indexOf("Monoclonal antibodies") >= 0) {
-        //         var splitInstr = instrWithHyperlink.split("Monoclonal antibodies");
-        //         instrWithHyperlink = splitInstr[0] + "<a href=\"#mabgrid\">Monoclonal antibodies</a>" + splitInstr[1];
-        //     }
-        //     if (instrWithHyperlink.indexOf("Plot") >= 0) {
-        //         var splitPlot = instrWithHyperlink.split("Plot");
-        //         instrWithHyperlink = splitPlot[0] + "<a href=\"#chart\">Plot</a>" + splitPlot[1];
-        //     }
-        //     if (instrWithHyperlink.indexOf("Grid") >= 0) {
-        //         var splitGrid = instrWithHyperlink.split("Grid");
-        //         instrWithHyperlink = splitGrid[0] + "<a href=\"#data\">Grid</a>" + splitGrid[1];
-        //     }
-        // }
+        if (instructions) {
+            if (instrWithHyperlink.indexOf("Monoclonal antibodies") >= 0) {
+                var splitInstr = instrWithHyperlink.split("Monoclonal antibodies");
+                instrWithHyperlink = splitInstr[0] + "<a class=\"instruction\" href=\"#mabgrid\">Monoclonal antibodies</a>" + splitInstr[1];
+            }
+            if (instrWithHyperlink.indexOf("Plot") >= 0) {
+                var splitPlot = instrWithHyperlink.split("Plot");
+                instrWithHyperlink = splitPlot[0] + "<a class=\"instruction\" href=\"#chart\">Plot</a>" + splitPlot[1];
+            }
+            if (instrWithHyperlink.indexOf("Grid") >= 0) {
+                var splitGrid = instrWithHyperlink.split("Grid");
+                instrWithHyperlink = splitGrid[0] + "<a class=\"instruction\" href=\"#data\">Grid</a>" + splitGrid[1];
+            }
+        }
 
         return instrWithHyperlink;
     },


### PR DESCRIPTION
#### Rationale
Added Plot, Grid, Monoclonal Antibodies links back (as implemented by Binal) with fixed tooltips

#### Changes
* Uncomment addition of links
* Add classes to links and filter those links out when applying mouseover actions
