### PR TITLE
Fix modal styles

### DIFF
--- a/src/org/labkey/cds/view/template/FrontPage.jsp
+++ b/src/org/labkey/cds/view/template/FrontPage.jsp
@@ -725,7 +725,7 @@
                         Sign up for our mailing list
                     </a>
                     <div class="email-modal-popup hidden">
-                        <div class="email-modal">
+                        <div class="email-modal front-page-popup-container">
                             <div class="border"></div>
                             <!-- Begin MailChimp Signup Form -->
                             <!-- <link href="//cdn-images.mailchimp.com/embedcode/slim-081711.css" rel="stylesheet" type="text/css">-->

--- a/theme/front-page/index/modal.scss
+++ b/theme/front-page/index/modal.scss
@@ -1,10 +1,7 @@
 @import '../variables';
 @import '../mixins';
 
-.signin-modal,
-.create-new-password-modal,
-.create-account-modal,
-.email-modal {
+.front-page-popup-container {
   position: relative;
   overflow: hidden;
   background: $background-color;


### PR DESCRIPTION
#### Rationale
Modal styles were broken.

Previous styles were never checked into the source sass files, so they were not included when we re-built the front page styles with the new build.

Instead of adding a selector for each individual modal I changed the selector to the "front-page-popup-container" which all modals except email had. Added front-page-popup-container to the email modal.

#### Related Pull Requests
* n/a

#### Changes
* Change selector for modal styles to use front-page-popup-container
* Add front-page-popup-container class to email modal
