### PR TITLE
Bind the enter key to the register account form.

### DIFF
--- a/webapp/frontPage/js/modal.js
+++ b/webapp/frontPage/js/modal.js
@@ -168,6 +168,16 @@ define(['jquery', 'magnific', 'util'], function($, magnific, util) {
           }
         });
       }
+
+      var $createaccountcontainer = self.$modal.find('[id=registeraccountform]');
+      if ($createaccountcontainer.length > 0) {
+        $("#registeraccountform input").keypress(function (e) {
+          if (e.keyCode == 13) {
+            e.preventDefault();
+            $('#registeraccountsubmit').click();
+          }
+        });
+      }
     };
 
     /**


### PR DESCRIPTION
#### Rationale
Fixes this issue:
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43179

#### Changes
The registration modal previously did not bind the enter key, so if a user wanted to use keyboard navigation and submit the form after filling in the kaptcha it wouldn't have the same effect as clicking on the submit button. This change uses the same pattern as some of the other modals to bind the enter key to the form submission button.