### PR TITLE
Feature Request 42388: Update search result message to be more helpful

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ webapp/frontPage/css/application.css
 
 node_modules/
 .gradle/
+
+resources/web/cds/gen/*

--- a/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
+++ b/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
@@ -893,6 +893,12 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
         checker().verifyTrue("Backbone with expected value 'SG3 beta env 2' is not visible.",
                 Locator.tagWithClass("div", "detail-gray-text").withText("SG3 beta env 2").findElement(rowElement).isDisplayed());
 
+        log("Searching for a string '" + MISSING_SEARCH_STRING + "' that should not be found.");
+        sleep(CDSHelper.CDS_WAIT_ANIMATION);
+        this.setFormElement(Locator.xpath(XPATH_TEXTBOX), MISSING_SEARCH_STRING);
+        sleep(CDSHelper.CDS_WAIT);
+        _asserts.verifyEmptyLearnAboutMAbProductsPage();
+
     }
 
     @Test

--- a/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
+++ b/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
@@ -894,6 +894,7 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
                 Locator.tagWithClass("div", "detail-gray-text").withText("SG3 beta env 2").findElement(rowElement).isDisplayed());
 
         log("Searching for a string '" + MISSING_SEARCH_STRING + "' that should not be found.");
+        cds.viewLearnAboutPage("MAbs");
         sleep(CDSHelper.CDS_WAIT_ANIMATION);
         this.setFormElement(Locator.xpath(XPATH_TEXTBOX), MISSING_SEARCH_STRING);
         sleep(CDSHelper.CDS_WAIT);

--- a/test/src/org/labkey/test/util/cds/CDSAsserts.java
+++ b/test/src/org/labkey/test/util/cds/CDSAsserts.java
@@ -202,9 +202,9 @@ public class CDSAsserts
 
     public void verifyEmptyLearnAboutMAbProductsPage()
     {
-        _test.assertElementPresent(Locator.xpath("//div[contains(@class, 'detail-empty-text')][text() = 'No available products meet your selection criteria.']"));
+        _test.assertElementPresent(Locator.xpath("//div[contains(@class, 'detail-empty-text')][text() = 'No available Monoclonal Antibodies meet your selection criteria.']"));
         _test.assertElementPresent(Locator.xpath("//div[contains(@class, 'detail-empty-subtext')][text() = 'Search returns exact match on text. Try adjusting your search.']"));
-        _test.assertElementPresent(Locator.xpath("//div[contains(@class, 'detail-empty-subtext')][text() = 'Also try searching for mAb in Studies section']"));
+        _test.assertElementPresent(Locator.xpath("//div[contains(@class, 'detail-empty-subtext')][text() = 'Also try searching for mAb in Studies section.']"));
     }
 
     public void verifyEmptyLearnAboutPublicationsPage()

--- a/test/src/org/labkey/test/util/cds/CDSAsserts.java
+++ b/test/src/org/labkey/test/util/cds/CDSAsserts.java
@@ -190,16 +190,27 @@ public class CDSAsserts
     public void verifyEmptyLearnAboutStudyPage()
     {
         _test.assertElementPresent(Locator.xpath("//div[contains(@class, 'detail-empty-text')][text() = 'No available studies meet your selection criteria.']"));
+        _test.assertElementPresent(Locator.xpath("//div[contains(@class, 'detail-empty-subtext')][text() = 'Search returns exact match on text. Try adjusting your search.']"));
     }
 
     public void verifyEmptyLearnAboutStudyProductsPage()
     {
         _test.assertElementPresent(Locator.xpath("//div[contains(@class, 'detail-empty-text')][text() = 'No available products meet your selection criteria.']"));
+        _test.assertElementPresent(Locator.xpath("//div[contains(@class, 'detail-empty-subtext')][text() = 'Search returns exact match on text. Try adjusting your search.']"));
+        _test.assertElementPresent(Locator.xpath("//div[contains(@class, 'detail-empty-subtext')][text() = 'Also try searching for product in Studies section.']"));
+    }
+
+    public void verifyEmptyLearnAboutMAbProductsPage()
+    {
+        _test.assertElementPresent(Locator.xpath("//div[contains(@class, 'detail-empty-text')][text() = 'No available products meet your selection criteria.']"));
+        _test.assertElementPresent(Locator.xpath("//div[contains(@class, 'detail-empty-subtext')][text() = 'Search returns exact match on text. Try adjusting your search.']"));
+        _test.assertElementPresent(Locator.xpath("//div[contains(@class, 'detail-empty-subtext')][text() = 'Also try searching for mAb in Studies section']"));
     }
 
     public void verifyEmptyLearnAboutPublicationsPage()
     {
         _test.assertElementPresent(Locator.xpath("//div[contains(@class, 'detail-empty-text')][text() = 'No available publications meet your selection criteria.']"));
+        _test.assertElementPresent(Locator.xpath("//div[contains(@class, 'detail-empty-subtext')][text() = 'Search returns exact match on text. Try adjusting your search.']"));
     }
 
     public void assertDefaultFilterStatusCounts()

--- a/theme/connector/view/_Learn.scss
+++ b/theme/connector/view/_Learn.scss
@@ -619,8 +619,14 @@ img.detail-has-data-small {
 
     .detail-empty-text {
       color: black;
-      height: 60px;
+      height: 40px;
       font: $display-two-font;
+    }
+
+    .detail-empty-subtext {
+      color: gray;
+      height: 30px;
+      font: $headline-font;
     }
   }
 }

--- a/webapp/Connector/src/app/view/LearnSummary.js
+++ b/webapp/Connector/src/app/view/LearnSummary.js
@@ -36,8 +36,10 @@ Ext.define('Connector.app.view.LearnSummary', {
         this.addEvents("learnGridResizeHeight");
 
         this.lockedViewConfig.emptyText = new Ext.XTemplate(
-                '<div class="detail-empty-text">No available {itemPluralName} meet your selection criteria.</div>'
-        ).apply({itemPluralName: this.itemPluralName});
+                '<div class="detail-empty-text">No available {itemPluralName} meet your selection criteria.</div>' +
+                '<div class="detail-empty-subtext">Search returns exact match on text. Try adjusting your search.</div>' +
+                '<tpl if="emptySearchSubtext"><div class="detail-empty-subtext">{emptySearchSubtext}</div></tpl>'
+        ).apply({itemPluralName: this.itemPluralName, emptySearchSubtext: this.emptySearchSubtext});
 
         this.normalGridConfig.listeners = {
             itemmouseenter : function(view, record, item, index, evt) {

--- a/webapp/Connector/src/app/view/MAb.js
+++ b/webapp/Connector/src/app/view/MAb.js
@@ -15,6 +15,8 @@ Ext.define('Connector.app.view.MAb', {
 
     itemPluralName: 'Monoclonal Antibodies',
 
+    emptySearchSubtext: 'Also try searching for mAb in Studies section.',
+
     columns: [
         {
             text: 'MAb/Mixture',

--- a/webapp/Connector/src/app/view/StudyProducts.js
+++ b/webapp/Connector/src/app/view/StudyProducts.js
@@ -11,7 +11,7 @@ Ext.define('Connector.app.view.StudyProducts', {
 
     itemPluralName: 'products',
 
-    emptySearchSubtext: 'Also try searching for products in Studies section.',
+    emptySearchSubtext: 'Also try searching for product in Studies section.',
 
     statics: {
         searchFields: ['product_name', 'product_description', 'product_type', 'product_class', 'product_class_label', 'product_subclass', 'product_developer']

--- a/webapp/Connector/src/app/view/StudyProducts.js
+++ b/webapp/Connector/src/app/view/StudyProducts.js
@@ -11,6 +11,8 @@ Ext.define('Connector.app.view.StudyProducts', {
 
     itemPluralName: 'products',
 
+    emptySearchSubtext: 'Also try searching for products in Studies section.',
+
     statics: {
         searchFields: ['product_name', 'product_description', 'product_type', 'product_class', 'product_class_label', 'product_subclass', 'product_developer']
     },


### PR DESCRIPTION
#### Rationale
Currently, the message that displays when there is no match for a search term on Learn - Products is, "No available products meet your search criteria". It has been suggested that this message could be more helpful by providing alternatives such as adding/removing spaces or other characters or by searching Learn - Studies.

#### Changes
* Update empty search message with custom message subtexts
