### PR TITLE
Ticket 43287: Add alternate login to the CDS production server

### DIFF
--- a/resources/views/customLogin.html
+++ b/resources/views/customLogin.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL=https://dataspace.cavd.org/cds/CAVD/app.view" />
+</head>

--- a/src/org/labkey/cds/CDSController.java
+++ b/src/org/labkey/cds/CDSController.java
@@ -173,6 +173,10 @@ public class CDSController extends SpringActionController
         {
             if (getContainer().isRoot())
                 throw new NotFoundException();
+
+            if (getUser().isGuest())
+                return new JspView("/org/labkey/cds/view/app.jsp");
+
             return new JspView("/org/labkey/cds/view/begin.jsp");
         }
 


### PR DESCRIPTION
#### Rationale
Ticket [43287](https://www.labkey.org/Dataspace/Support%20Tickets/issues-details.view?issueId=43287): Add alternate login to the CDS production server

#### Changes
* Add customLogin page to redirect users to cds login page
* Route guest user to cds app login page from cds.begin