### PR TITLE
Increase margin for the frontpage welcome message

### DIFF
--- a/theme/front-page/index/sections.scss
+++ b/theme/front-page/index/sections.scss
@@ -67,7 +67,10 @@
     overflow: hidden;
     margin: 2.67em 0;
     @include tablet {
-      margin: 3em 0em 2.67em 0;
+      margin: 3em 0 2.67em 0;
+    }
+    @include legacy-desktop {
+      margin: 10.67em 0 2.67em 0;
     }
     .title {
       margin-bottom: 2.67em;

--- a/theme/front-page/mixins.scss
+++ b/theme/front-page/mixins.scss
@@ -31,6 +31,12 @@
 	}
 }
 
+@mixin legacy-desktop {
+	@media only screen and (max-height : $legacy-desktop-height) {
+		@content;
+	}
+}
+
 @mixin phone {
 	@media only screen and (max-width : $phone-width) {
 		@content;

--- a/theme/front-page/variables.scss
+++ b/theme/front-page/variables.scss
@@ -16,4 +16,5 @@ $lighter-grey-text: #969696;
 $max-width: 1280px;
 $tablet-width: 700px;
 $phone-width: 480px;
+$legacy-desktop-height: 864px;
 $fullpage-navigation-max-width: 800px;


### PR DESCRIPTION
#### Rationale
This issue : https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43339 reports that the welcome message gets clipped by the registration div when the window height gets too short.

![image](https://user-images.githubusercontent.com/5741543/121575685-7fdb5200-c9dc-11eb-82be-8ad45355e194.png)

This isn't a problem on higher resolution screens but could be problematic with legacy desktop screens or if the window was sized too short.

#### Changes
- Introduce a mixin : legacy-desktop which is triggered on window sizes shorter than 864px
- Increase the welcome div margin from 2.67 to 10.67em when the threshold is triggered
- Note that there was currently a tablet mixin, but that rule was triggered when the window width was less than 700px