### PR TITLE
43362: Outage notice out of place on CDS login page

### DIFF
--- a/theme/front-page/application.scss
+++ b/theme/front-page/application.scss
@@ -7,3 +7,4 @@
 @import 'index/modal';
 @import 'index/sections';
 @import 'index/overrides';
+@import 'index/notification';

--- a/theme/front-page/index/notification.scss
+++ b/theme/front-page/index/notification.scss
@@ -1,0 +1,43 @@
+@import '../variables';
+@import '../mixins';
+
+#notification {
+  top: 4.635em;
+  max-width: 1280px;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  display: none;
+  width: 100%;
+  min-height: 4.635em;
+  height: auto;
+  background-color: white;
+  position: fixed;
+  overflow: hidden;
+  z-index: 15;
+  padding: 0em;
+
+  .notification-messages {
+    position: relative;
+    left: 40px;
+    margin: 15px;
+    font-family: "Arial";
+    font-size: 14px;
+    color: #303030;
+  }
+
+  .warning {
+    position: absolute;
+    left: 0;
+    top: 0;
+    margin: 15px;
+  }
+
+  .dismiss {
+    position: absolute;
+    right: 0;
+    top: 0;
+    cursor: pointer;
+    margin: 15px;
+  }
+}


### PR DESCRIPTION
#### Rationale
If configured (from site settings) the ribbon message divs are styled incorrectly: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43362

#### Changes
During the conversion from Sencha Cmd to build the CDS stylesheets, the CSS for these divs did not get ported over, this change re-introduces the previous styles.