### PR TITLE
21.3 fb cds public site

### DIFF
--- a/resources/etls/RunTemplates.xml
+++ b/resources/etls/RunTemplates.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <etl xmlns="http://labkey.org/etl/xml">
-    <name>Run Reports : (runTemplate, create_static_site, create_neutralization_curves)</name>
+    <name>Run Reports : (create_static_site, create_neutralization_curves)</name>
     <description>Refresh public site pages and other reports</description>
     <transforms>
         <transform id="step1" type="TaskRefTransformStep">
             <taskref ref="org.labkey.di.pipeline.RunReportTask">
                 <settings>
-                    <setting name="reportId" value="db:runTemplates"/>
+                    <setting name="reportId" value="db:create_static_site"/>
                     <setting name="greeter" value="STEP1"/>
                 </settings>
             </taskref>
@@ -14,16 +14,8 @@
         <transform id="step2" type="TaskRefTransformStep">
             <taskref ref="org.labkey.di.pipeline.RunReportTask">
                 <settings>
-                    <setting name="reportId" value="db:create_static_site"/>
-                    <setting name="greeter" value="STEP2"/>
-                </settings>
-            </taskref>
-        </transform>
-        <transform id="step3" type="TaskRefTransformStep">
-            <taskref ref="org.labkey.di.pipeline.RunReportTask">
-                <settings>
                     <setting name="reportId" value="db:create_neutralization_curves"/>
-                    <setting name="greeter" value="STEP3"/>
+                    <setting name="greeter" value="STEP2"/>
                 </settings>
             </taskref>
         </transform>

--- a/resources/etls/RunTemplates.xml
+++ b/resources/etls/RunTemplates.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>Run Templates ETL</name>
+    <description>Refresh public site pages</description>
+    <transforms>
+        <transform id="step1" type="TaskRefTransformStep">
+            <taskref ref="org.labkey.di.pipeline.RunReportTask">
+                <settings>
+                    <setting name="reportId" value="module:cds/runTemplates.R"/>
+                    <setting name="greeter" value="STEP1"/>
+                </settings>
+            </taskref>
+        </transform>
+    </transforms>
+</etl>

--- a/resources/etls/RunTemplates.xml
+++ b/resources/etls/RunTemplates.xml
@@ -1,13 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <etl xmlns="http://labkey.org/etl/xml">
-    <name>Run Templates ETL</name>
-    <description>Refresh public site pages</description>
+    <name>Run Reports : (runTemplate, create_static_site, create_neutralization_curves)</name>
+    <description>Refresh public site pages and other reports</description>
     <transforms>
         <transform id="step1" type="TaskRefTransformStep">
             <taskref ref="org.labkey.di.pipeline.RunReportTask">
                 <settings>
-                    <setting name="reportId" value="module:cds/runTemplates.R"/>
+                    <setting name="reportId" value="db:runTemplates"/>
                     <setting name="greeter" value="STEP1"/>
+                </settings>
+            </taskref>
+        </transform>
+        <transform id="step2" type="TaskRefTransformStep">
+            <taskref ref="org.labkey.di.pipeline.RunReportTask">
+                <settings>
+                    <setting name="reportId" value="db:create_static_site"/>
+                    <setting name="greeter" value="STEP2"/>
+                </settings>
+            </taskref>
+        </transform>
+        <transform id="step3" type="TaskRefTransformStep">
+            <taskref ref="org.labkey.di.pipeline.RunReportTask">
+                <settings>
+                    <setting name="reportId" value="db:create_neutralization_curves"/>
+                    <setting name="greeter" value="STEP3"/>
                 </settings>
             </taskref>
         </transform>

--- a/src/org/labkey/cds/CDSModule.java
+++ b/src/org/labkey/cds/CDSModule.java
@@ -70,6 +70,7 @@ public class CDSModule extends DefaultModule
     public static final String TOURS_WIKI_LABEL = "ToursWiki";
     private static final String TOURS_WIKI_DEFAULT = "tour-default-wiki";
     private static final String WHATYOUNEEDTOKNOW_WIKI_DEFAULT = "needtoknow-default-wiki";
+    public static final String CDS_PUBLIC_PAGE_URL = "CDSPublicPageUrl";
 
     final ModuleProperty _showHiddenVariables;
     final ModuleProperty _blogPath;
@@ -158,6 +159,12 @@ public class CDSModule extends DefaultModule
         _takeATourWiki.setCanSetPerContainer(false);
         _takeATourWiki.setDefaultValue(TOURS_WIKI_DEFAULT);
         addModuleProperty(_takeATourWiki);
+
+        // public page root
+        ModuleProperty publicPageUrl = new ModuleProperty(this, CDS_PUBLIC_PAGE_URL);
+        publicPageUrl.setDescription("The webdav URL to the main public page.");
+        publicPageUrl.setCanSetPerContainer(false);
+        addModuleProperty(publicPageUrl);
     }
 
     @Override

--- a/src/org/labkey/cds/view/template/FrontPage.jsp
+++ b/src/org/labkey/cds/view/template/FrontPage.jsp
@@ -19,12 +19,8 @@
 <%@ page import="org.labkey.api.module.ModuleProperty" %>
 <%@ page import="org.labkey.api.util.PageFlowUtil" %>
 <%@ page import="org.labkey.cds.CDSModule" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
-<%
-    ModuleProperty mp = ModuleLoader.getInstance().getModule(CDSModule.class).getModuleProperties().get(CDSModule.CDS_PUBLIC_PAGE_URL);
-    String url = mp.getEffectiveValue(getContainer());
-%>
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -70,30 +66,11 @@
             window.location = LABKEY.ActionURL.buildURL('cds', 'app', LABKEY.container.path, {register: "TRUE"});
         };
 
-        clickPublicLink = function(hash) {
-            let url = <%=q(url)%>;
-            if (!url) {
-                alert('The module property for the public page URL has not been set.');
-            } else {
-                url = url + '#' + hash;
-                window.location = url;
-            }
-        }
-
-        initPublicLinks = function() {
-            $('span.public-page-link.study').on('click', function(){clickPublicLink('study');});
-            $('span.public-page-link.assay').on('click', function(){clickPublicLink('assay');});
-            $('div.public-page-link.study').on('click', function(){clickPublicLink('study');});
-            $('div.public-page-link.assay').on('click', function(){clickPublicLink('assay');});
-        };
-
         $(document).ready(function() {
             // notification close button
             $('div.dismiss').click(function(){
                 $('#notification').remove();
             });
-
-            initPublicLinks();
         });
     </script>
 </head>
@@ -587,7 +564,7 @@
             </div>
             <div class="learn-more">
                 <p>Learn, discover and collaborate on data</p>
-                <p>from dozens of <span class="public-page-link study">HIV vaccine studies.</span></p>
+                <p>from dozens of <a class="public-page-link" href="<%=getPublicPageURL("study")%>">HIV vaccine studies.</a></p>
                 <div class="container">
                     <h3>Learn more</h3>
                 </div>
@@ -607,38 +584,46 @@
                     <p>days ago.</p>
                 </div>
                 <div class="counts">
-                    <div class="products datapoint public-page-link study">
-                        <div class="value">
-                            <h1>-</h1>
+                    <a class="public-page-link" href="<%=getPublicPageURL("study")%>">
+                        <div class="products datapoint">
+                            <div class="value">
+                                <h1>-</h1>
+                            </div>
+                            <div class="title">
+                                <p>Products</p>
+                            </div>
                         </div>
-                        <div class="title">
-                            <p>Products</p>
+                    </a>
+                    <a class="public-page-link" href="<%=getPublicPageURL("study")%>">
+                        <div class="studies datapoint">
+                            <div class="value">
+                                <h1>-</h1>
+                            </div>
+                            <div class="title">
+                                <p>Studies</p>
+                            </div>
                         </div>
-                    </div>
-                    <div class="studies datapoint public-page-link study">
-                        <div class="value">
-                            <h1>-</h1>
+                    </a>
+                    <a class="public-page-link" href="<%=getPublicPageURL("study")%>">
+                        <div class="subjects datapoint">
+                            <div class="value">
+                                <h1>-</h1>
+                            </div>
+                            <div class="title">
+                                <p>Subjects</p>
+                            </div>
                         </div>
-                        <div class="title">
-                            <p>Studies</p>
+                    </a>
+                    <a class="public-page-link" href="<%=getPublicPageURL("assay")%>">
+                        <div class="assays datapoint">
+                            <div class="value">
+                                <h1>-</h1>
+                            </div>
+                            <div class="title">
+                                <p>Assays</p>
+                            </div>
                         </div>
-                    </div>
-                    <div class="subjects datapoint public-page-link study">
-                        <div class="value">
-                            <h1>-</h1>
-                        </div>
-                        <div class="title">
-                            <p>Subjects</p>
-                        </div>
-                    </div>
-                    <div class="assays datapoint public-page-link assay">
-                        <div class="value">
-                            <h1>-</h1>
-                        </div>
-                        <div class="title">
-                            <p>Assays</p>
-                        </div>
-                    </div>
+                    </a>
                 </div>
                 <div class="reminder">
                     <p>Our team regularly adds new data</p>
@@ -687,7 +672,8 @@
                 <img src="<%=getWebappURL("/frontpage/img/learn.png")%>" class="placeholder">
                 <img src="<%=getWebappURL("/frontpage/img/learn-complete.png")%>" class="mobile-img">
                 <div class="gif-description">
-                    <p>Learn details about dozens of <span class="public-page-link study">studies</span>, vaccines, and <span class="public-page-link assay">assays</span>
+                    <p>Learn details about dozens of <a class="public-page-link" href="<%=getPublicPageURL("study")%>">studies</a>, vaccines,
+                        and <a class="public-page-link" href="<%=getPublicPageURL("assay")%>">assays</a>
                         to avoid covering trodden ground and give context to new
                         proposals. </p>
                 </div>
@@ -802,3 +788,17 @@
     </div>
 </body>
 </html>
+
+<%!
+    private String _url;
+    private HtmlString getPublicPageURL(String hash)
+    {
+        if (_url == null)
+        {
+            ModuleProperty mp = ModuleLoader.getInstance().getModule(CDSModule.class).getModuleProperties().get(CDSModule.CDS_PUBLIC_PAGE_URL);
+            _url = mp.getEffectiveValue(getContainer());
+        }
+
+        return _url != null ? HtmlString.unsafe(String.format("%s#%s", _url, hash)) : HtmlString.unsafe("#");
+   }
+%>

--- a/src/org/labkey/cds/view/template/FrontPage.jsp
+++ b/src/org/labkey/cds/view/template/FrontPage.jsp
@@ -70,18 +70,21 @@
             window.location = LABKEY.ActionURL.buildURL('cds', 'app', LABKEY.container.path, {register: "TRUE"});
         };
 
-        clickPublicLink = function() {
+        clickPublicLink = function(hash) {
             let url = <%=q(url)%>;
             if (!url) {
                 alert('The module property for the public page URL has not been set.');
             } else {
+                url = url + '#' + hash;
                 window.location = url;
             }
         }
 
         initPublicLinks = function() {
-            $('span.public-page-link').on('click', clickPublicLink);
-            $('div.public-page-link').on('click', clickPublicLink);
+            $('span.public-page-link.study').on('click', function(){clickPublicLink('study');});
+            $('span.public-page-link.assay').on('click', function(){clickPublicLink('assay');});
+            $('div.public-page-link.study').on('click', function(){clickPublicLink('study');});
+            $('div.public-page-link.assay').on('click', function(){clickPublicLink('assay');});
         };
 
         $(document).ready(function() {
@@ -584,7 +587,7 @@
             </div>
             <div class="learn-more">
                 <p>Learn, discover and collaborate on data</p>
-                <p>from dozens of <span class="public-page-link">HIV vaccine studies.</span></p>
+                <p>from dozens of <span class="public-page-link study">HIV vaccine studies.</span></p>
                 <div class="container">
                     <h3>Learn more</h3>
                 </div>
@@ -603,8 +606,8 @@
                     <p class="days">-</p>
                     <p>days ago.</p>
                 </div>
-                <div class="counts public-page-link">
-                    <div class="products datapoint">
+                <div class="counts">
+                    <div class="products datapoint public-page-link study">
                         <div class="value">
                             <h1>-</h1>
                         </div>
@@ -612,7 +615,7 @@
                             <p>Products</p>
                         </div>
                     </div>
-                    <div class="studies datapoint">
+                    <div class="studies datapoint public-page-link study">
                         <div class="value">
                             <h1>-</h1>
                         </div>
@@ -620,7 +623,7 @@
                             <p>Studies</p>
                         </div>
                     </div>
-                    <div class="subjects datapoint">
+                    <div class="subjects datapoint public-page-link study">
                         <div class="value">
                             <h1>-</h1>
                         </div>
@@ -628,7 +631,7 @@
                             <p>Subjects</p>
                         </div>
                     </div>
-                    <div class="assays datapoint">
+                    <div class="assays datapoint public-page-link assay">
                         <div class="value">
                             <h1>-</h1>
                         </div>
@@ -684,7 +687,7 @@
                 <img src="<%=getWebappURL("/frontpage/img/learn.png")%>" class="placeholder">
                 <img src="<%=getWebappURL("/frontpage/img/learn-complete.png")%>" class="mobile-img">
                 <div class="gif-description">
-                    <p>Learn details about dozens of <span class="public-page-link">studies</span>, vaccines, and <span class="public-page-link">assays</span>
+                    <p>Learn details about dozens of <span class="public-page-link study">studies</span>, vaccines, and <span class="public-page-link assay">assays</span>
                         to avoid covering trodden ground and give context to new
                         proposals. </p>
                 </div>

--- a/src/org/labkey/cds/view/template/FrontPage.jsp
+++ b/src/org/labkey/cds/view/template/FrontPage.jsp
@@ -15,8 +15,16 @@
  * limitations under the License.
  */
 %>
+<%@ page import="org.labkey.api.module.ModuleLoader" %>
+<%@ page import="org.labkey.api.module.ModuleProperty" %>
 <%@ page import="org.labkey.api.util.PageFlowUtil" %>
+<%@ page import="org.labkey.cds.CDSModule" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%
+    ModuleProperty mp = ModuleLoader.getInstance().getModule(CDSModule.class).getModuleProperties().get(CDSModule.CDS_PUBLIC_PAGE_URL);
+    String url = mp.getEffectiveValue(getContainer());
+%>
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -62,11 +70,27 @@
             window.location = LABKEY.ActionURL.buildURL('cds', 'app', LABKEY.container.path, {register: "TRUE"});
         };
 
+        clickPublicLink = function() {
+            let url = <%=q(url)%>;
+            if (!url) {
+                alert('The module property for the public page URL has not been set.');
+            } else {
+                window.location = url;
+            }
+        }
+
+        initPublicLinks = function() {
+            $('span.public-page-link').on('click', clickPublicLink);
+            $('div.public-page-link').on('click', clickPublicLink);
+        };
+
         $(document).ready(function() {
             // notification close button
             $('div.dismiss').click(function(){
                 $('#notification').remove();
             });
+
+            initPublicLinks();
         });
     </script>
 </head>
@@ -560,7 +584,7 @@
             </div>
             <div class="learn-more">
                 <p>Learn, discover and collaborate on data</p>
-                <p>from dozens of HIV vaccine studies.</p>
+                <p>from dozens of <span class="public-page-link">HIV vaccine studies.</span></p>
                 <div class="container">
                     <h3>Learn more</h3>
                 </div>
@@ -579,7 +603,7 @@
                     <p class="days">-</p>
                     <p>days ago.</p>
                 </div>
-                <div class="counts">
+                <div class="counts public-page-link">
                     <div class="products datapoint">
                         <div class="value">
                             <h1>-</h1>
@@ -660,7 +684,7 @@
                 <img src="<%=getWebappURL("/frontpage/img/learn.png")%>" class="placeholder">
                 <img src="<%=getWebappURL("/frontpage/img/learn-complete.png")%>" class="mobile-img">
                 <div class="gif-description">
-                    <p>Learn details about dozens of studies, vaccines, and assays
+                    <p>Learn details about dozens of <span class="public-page-link">studies</span>, vaccines, and <span class="public-page-link">assays</span>
                         to avoid covering trodden ground and give context to new
                         proposals. </p>
                 </div>

--- a/theme/front-page/index/sections.scss
+++ b/theme/front-page/index/sections.scss
@@ -411,3 +411,17 @@
     margin: 6.5em auto 1.833em auto;
   }
 }
+
+span.public-page-link {
+  color: $navigation-pink;
+  cursor: pointer;
+}
+
+div.public-page-link {
+  cursor: pointer;
+  p, h1 {
+    &:hover {
+      color: $navigation-pink !important;
+    }
+  }
+}

--- a/theme/front-page/index/sections.scss
+++ b/theme/front-page/index/sections.scss
@@ -412,13 +412,12 @@
   }
 }
 
-span.public-page-link {
+a.public-page-link {
   color: $navigation-pink;
-  cursor: pointer;
+  text-decoration: none;
 }
 
-div.public-page-link {
-  cursor: pointer;
+a.public-page-link {
   p, h1 {
     &:hover {
       color: $navigation-pink !important;


### PR DESCRIPTION
#### Rationale
This feature request : https://www.labkey.org/Dataspace/Feature%20Requests/issues-details.view?issueId=42300 adds support for integrating static html pages from the front page for guest users.

Dev summary and setup instructions can be found here : https://docs.google.com/document/d/1h0TBk6I1qNYsNLPDifqHjhCVytvaDafNu5HAwf6wLWE/edit

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/2363

#### Changes
- Add an ETL to run pre-configured R reports
- Introduce an module property to configure the public page URL
- Add public page links to the front page
