### PR TITLE
Fix Security Test in CDS

### DIFF
--- a/test/src/org/labkey/test/pages/cds/CDSCreateAccountPage.java
+++ b/test/src/org/labkey/test/pages/cds/CDSCreateAccountPage.java
@@ -1,0 +1,90 @@
+package org.labkey.test.pages.cds;
+
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.components.ext4.Checkbox;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+// This is a page in only the general sense. It is not like current pages in other automation but is similar to other
+// sign-in page in CDS. yes it should be updated, but so should all of CDS, and no we don't have the time or budget to do that.
+public class CDSCreateAccountPage
+{
+    private final BaseWebDriverTest _test;
+
+    public CDSCreateAccountPage(BaseWebDriverTest test)
+    {
+        _test = test;
+        // Wait until the signInButton is visible (not null) before returning.
+        WebDriverWrapper.waitFor(()->submitButton() != null, "Create Account page did not load.", 5_000);
+    }
+
+    public void setPasswordField(String password)
+    {
+        _test.setFormElement(passwordField(), password);
+    }
+
+    public void setReenterPasswordField(String password)
+    {
+        _test.setFormElement(reenterPasswordField(), password);
+    }
+
+    public void clickSubmitButton()
+    {
+        submitButton().click();
+    }
+
+    public void checkTermsBox(boolean check)
+    {
+        if(check && !termsCheckbox().isChecked())
+        {
+            termsCheckbox().check();
+        }
+
+        if(!check && termsCheckbox().isChecked())
+        {
+            termsCheckbox().uncheck();
+        }
+    }
+
+    private WebElement findVisible(Locator locator)
+    {
+        // Yes this is ugly. This is the check to identify the visible control. Currently for the number of CDS tests
+        // that use the login page the call to findElements for the page will return only two or three controls.
+        WebElement element = null;
+        List<WebElement> elements = locator.findElements(_test.getDriver());
+        for(WebElement el : elements)
+        {
+            if(el.isDisplayed())
+            {
+                element = el;
+                break;
+            }
+        }
+
+        return element;
+    }
+
+    public WebElement passwordField()
+    {
+        return findVisible(Locator.name("password"));
+    }
+
+    public WebElement reenterPasswordField()
+    {
+        return findVisible(Locator.name("reenter-password"));
+    }
+
+    public WebElement submitButton()
+    {
+        return findVisible(Locator.tagWithId("input", "createaccountsubmit"));
+    }
+
+    public Checkbox termsCheckbox()
+    {
+        return new Checkbox(findVisible(Locator.checkboxById("tos-create-account")));
+    }
+
+}

--- a/test/src/org/labkey/test/tests/cds/CDSSecurityTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSSecurityTest.java
@@ -23,6 +23,7 @@ import org.labkey.remoteapi.CommandException;
 import org.labkey.test.Locator;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.dumbster.EmailRecordTable;
+import org.labkey.test.pages.cds.CDSCreateAccountPage;
 import org.labkey.test.pages.cds.LearnGrid;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.Ext4Helper;
@@ -971,13 +972,14 @@ public class CDSSecurityTest extends CDSReadOnlyTest
 
     private void handleCreateAccount(String password, boolean agreeToTOS)
     {
-        setFormElement(Locator.css("input[name='password']"), password);
-        setFormElement(Locator.css("input[name='reenter-password']"), password);
+        CDSCreateAccountPage createAccountPage = new CDSCreateAccountPage(this);
+        createAccountPage.setPasswordField(password);
+        createAccountPage.setReenterPasswordField(password);
         if (agreeToTOS)
         {
-            checkCheckbox(Locator.css("input[id='tos-create-account']"));
+            createAccountPage.checkTermsBox(true);
         }
-            click(Locator.css("input[id='createaccountsubmit']"));
+        createAccountPage.clickSubmitButton();
     }
 
     private void handleSimpleLogin(String email, String password)


### PR DESCRIPTION
#### Rationale
The CDS Security Test have started failing. The failure is caused by the test not checking if the control it has, in this case for the password, is the one visible on the page, or one that is hidden. This change adds a "page" that will help make sure the test is using the visible control.

#### Related Pull Requests
* None

#### Changes
* Added a CreateAccount "page".
* Updated security test to use the page.
