### PR TITLE
21.7 fb data availability publication

### DIFF
--- a/resources/queries/cds/learn_publicationsforstudies.sql
+++ b/resources/queries/cds/learn_publicationsforstudies.sql
@@ -19,8 +19,14 @@ SELECT
   sp.publication_order,
   s.label AS "study_label",
   s.short_name AS "study_short_name",
-  pub.*
+  pub.*,
+  COUNT(pd.document_id) AS available_data_count
 FROM cds.ds_studypublication sp
 LEFT JOIN publication pub
 ON pub.id=sp.publication_id
 LEFT JOIN cds.metadata.study s ON sp.prot=s.study_name
+LEFT JOIN cds.publicationDocument pd ON sp.publication_id = pd.publication_id
+GROUP BY sp.prot, sp.publication_order, s.label, s.short_name,
+         pub.id, pub.container, pub.title, pub.author_all, pub.journal_short,
+         pub.date, pub.volume, pub.issue, pub.location, pub.pmid, pub.link,
+         pub.author_first, pub.publication_label

--- a/theme/connector/view/_Learn.scss
+++ b/theme/connector/view/_Learn.scss
@@ -385,6 +385,13 @@ img.detail-has-data-small {
   height: 20px
 }
 
+img.detail-has-data-very-small {
+  margin-right: 3px;
+  margin-left: 3px;
+  width: 11px;
+  height: 11px
+}
+
 .data-availability-header {
   padding-bottom: 20px;
   color: $heat-scale-2;

--- a/theme/connector/view/_Learn.scss
+++ b/theme/connector/view/_Learn.scss
@@ -374,6 +374,9 @@ h1.lhdv {
   &.detail-has-data-green {
     background-image: url(images/learn/bigCheck.png);
   }
+  &.detail-has-data-ni {
+    background-image: url(images/learn/ni-added.svg);
+  }
 }
 
 img.detail-has-data-small {

--- a/webapp/Connector/src/app/model/Publication.js
+++ b/webapp/Connector/src/app/model/Publication.js
@@ -13,7 +13,7 @@ Ext.define('Connector.app.model.Publication', {
 
     labelProperty: 'publication_label',
 
-    dataAvailabilityField: 'studies',
+    dataAvailabilityField: 'publication_data',
 
     fields: [
         {name: 'publication_id'},
@@ -31,6 +31,7 @@ Ext.define('Connector.app.model.Publication', {
         {name: 'publication_label'},
         {name: 'publication_data', convert : Connector.model.Filter.asArray},
         {name: 'publication_data_count'},
+        {name: 'data_availability'},
         {name: 'year'},
         {name: 'study_to_sort_on'},
         {name: 'study_names', convert : Connector.model.Filter.asArray},

--- a/webapp/Connector/src/app/model/Publication.js
+++ b/webapp/Connector/src/app/model/Publication.js
@@ -30,7 +30,7 @@ Ext.define('Connector.app.model.Publication', {
         {name: 'author_first'},
         {name: 'publication_label'},
         {name: 'publication_data', convert : Connector.model.Filter.asArray},
-
+        {name: 'publication_data_count'},
         {name: 'year'},
         {name: 'study_to_sort_on'},
         {name: 'study_names', convert : Connector.model.Filter.asArray},

--- a/webapp/Connector/src/app/store/Publication.js
+++ b/webapp/Connector/src/app/store/Publication.js
@@ -255,6 +255,7 @@ Ext.define('Connector.app.store.Publication', {
 
                 // publication data
                 publication.publication_data = publicationMap[publication.publication_id] || [];
+                publication.publication_data_count = publication.publication_data.length;
 
                 //saved reports
                 var savedRep = savedReports.filter(function (value) {

--- a/webapp/Connector/src/app/store/Publication.js
+++ b/webapp/Connector/src/app/store/Publication.js
@@ -193,7 +193,8 @@ Ext.define('Connector.app.store.Publication', {
                     isLinkValid: undefined,
                     hasPermission: true,                // publication documents are always public
                     suffix: '(' + Connector.utility.FileExtension.fileDisplayType(doc.filename) +')',
-                    filePath: Connector.plugin.DocumentValidation.getPublicationDocumentUrl(doc.filename, doc.document_id)
+                    filePath: Connector.plugin.DocumentValidation.getPublicationDocumentUrl(doc.filename, doc.document_id),
+                    has_access: true                    // needed for the data available tooltip on the learn page
                 }
             }, this).sort(function(docA, docB){
                 return Connector.model.Filter.sorters.natural(docA.label, docB.label);
@@ -256,6 +257,7 @@ Ext.define('Connector.app.store.Publication', {
                 // publication data
                 publication.publication_data = publicationMap[publication.publication_id] || [];
                 publication.publication_data_count = publication.publication_data.length;
+                publication.data_availability = publication.publication_data.length > 0;
 
                 //saved reports
                 var savedRep = savedReports.filter(function (value) {

--- a/webapp/Connector/src/app/store/Study.js
+++ b/webapp/Connector/src/app/store/Study.js
@@ -305,7 +305,8 @@ Ext.define('Connector.app.store.Study', {
                         location: pub.location,
                         pmid: pub.pmid,
                         link: pub.link,
-                        sortIndex: pub.publication_order
+                        sortIndex: pub.publication_order,
+                        available_data_count: pub.available_data_count
                     };
                 }).sort(function(pubA, pubB){
                     return ((pubA.sortIndex || 0) - (pubB.sortIndex || 0)) ||

--- a/webapp/Connector/src/app/view/LearnSummary.js
+++ b/webapp/Connector/src/app/view/LearnSummary.js
@@ -95,6 +95,7 @@ Ext.define('Connector.app.view.LearnSummary', {
 
     showDataAvailabilityTooltip : function(event, item, options) {
         var config = this.dataAvailabilityTooltipConfig();
+        var labelField = config.labelField || 'data_label';
 
         var dataAvailableListHTML = "<ul>";
         var records = options.itemsWithDataAvailable, accessible = [], nonAccessible = [];
@@ -104,23 +105,21 @@ Ext.define('Connector.app.view.LearnSummary', {
             else
                 nonAccessible.push(record);
         });
-        if (accessible.length > 0)
-        {
+        if (accessible.length > 0) {
             dataAvailableListHTML += '<p class="data-availability-tooltip-header">' + config.title + " with Data Accessible" + '</p>';
             dataAvailableListHTML += "<ul>";
             Ext.each(accessible, function(record){
-                dataAvailableListHTML += "<li>" + record['data_label'] + "</li>\n";
+                dataAvailableListHTML += "<li>" + record[labelField] + "</li>\n";
             });
             dataAvailableListHTML += "</ul>";
         }
-        if (nonAccessible.length > 0)
-        {
+        if (nonAccessible.length > 0) {
             if (accessible.length > 0)
                 dataAvailableListHTML += '<br>';
             dataAvailableListHTML += '<p class="data-availability-tooltip-header">' + config.title + " without Data Accessible" + '</p>';
             dataAvailableListHTML += "<ul>";
             Ext.each(nonAccessible, function(record){
-                dataAvailableListHTML += "<li>" + record['data_label'] + "</li>\n";
+                dataAvailableListHTML += "<li>" + record[labelField] + "</li>\n";
             });
             dataAvailableListHTML += "</ul>";
         }

--- a/webapp/Connector/src/app/view/Publication.js
+++ b/webapp/Connector/src/app/view/Publication.js
@@ -37,10 +37,31 @@ Ext.define('Connector.app.view.Publication', {
                     '</div>',
                     '</div>')
         },{
+            text: 'Data Added',
+            xtype: 'templatecolumn',
+            minWidth: 150,
+            flex: 1/7,
+            resizable: false,
+            dataIndex: 'publication_data',
+            filterConfigSet: [{
+                filterField: 'publication_data_count',
+                valueType: 'number',
+                title: 'publication data count'
+            }],
+            tpl: new Ext.XTemplate(
+                '<div class="detail-text">',
+                    '<tpl if="publication_data.length &gt; 0">',
+                        '<div class="detail-has-data detail-has-data-ni"></div>',
+                    '<tpl else>',
+                        'Data not added',
+                    '</tpl>',
+                '</div>'
+            )
+        },{
             text: 'Journal',
             xtype: 'templatecolumn',
             minWidth: 150,
-            flex: 1/6,
+            flex: 1/7,
             resizable: false,
             dataIndex: 'journal_short',
             filterConfigSet: [{
@@ -57,7 +78,7 @@ Ext.define('Connector.app.view.Publication', {
             text: 'First Author',
             xtype: 'templatecolumn',
             minWidth: 150,
-            flex: 1/6,
+            flex: 1/7,
             resizable: false,
             dataIndex: 'author_first',
             filterConfigSet: [{
@@ -74,7 +95,7 @@ Ext.define('Connector.app.view.Publication', {
             text: 'Publication Date',
             xtype: 'templatecolumn',
             minWidth: 150,
-            flex: 1/6,
+            flex: 1/7,
             resizable: false,
             dataIndex: 'date',
             filterConfigSet: [{
@@ -91,7 +112,7 @@ Ext.define('Connector.app.view.Publication', {
             text: 'Studies',
             xtype: 'templatecolumn',
             minWidth: 150,
-            flex: 1/6,
+            flex: 1/7,
             resizable: false,
             dataIndex: 'study_to_sort_on',
             filterConfigSet: [{
@@ -119,7 +140,7 @@ Ext.define('Connector.app.view.Publication', {
             text: 'PubMed Id',
             xtype: 'templatecolumn',
             minWidth: 150,
-            flex: 1/6,
+            flex: 1/7,
             resizable: false,
             dataIndex: 'pmid',
             filterConfigSet: [{

--- a/webapp/Connector/src/app/view/Publication.js
+++ b/webapp/Connector/src/app/view/Publication.js
@@ -160,6 +160,12 @@ Ext.define('Connector.app.view.Publication', {
         searchFields: [
             'publication_title', 'author_all', 'pmid', 'journal_short'
         ]
-    }
+    },
 
+    dataAvailabilityTooltipConfig : function() {
+        return {
+            title: 'Publications',
+            labelField : 'label'
+        }
+    }
 });

--- a/webapp/Connector/src/app/view/module/StudyPublications.js
+++ b/webapp/Connector/src/app/view/module/StudyPublications.js
@@ -23,7 +23,7 @@ Ext.define('Connector.view.module.StudyPublications', {
                                 '<tr>',
                                     '<td class="item-value">',
                                     '<tpl if="label">',
-                                        '<a href="#learn/learn/Publication/{id}">{label:htmlEncode}: </a>',
+                                        '{[this.getPublicationLink(values)]}',
                                     '</tpl>',
                                     '{authors:htmlEncode}. {title:htmlEncode}. {journal:htmlEncode}. {date:htmlEncode}',
                                     '<tpl if="volume || issue">',
@@ -98,7 +98,23 @@ Ext.define('Connector.view.module.StudyPublications', {
                         '</table>',
 
                 '</tpl>',
-            '</tpl>'
+            '</tpl>',
+            {
+                getPublicationLink : function(row) {
+                    let link = '<a href="#learn/learn/Publication/';
+
+                    link += row.id;
+                    link += '">';
+                    link += Ext.htmlEncode(row.label);
+                    if (row.available_data_count > 0) {
+                        // add the non-integrated data available icon
+                        link += '<img class="detail-has-data-very-small" src="' + Connector.resourceContext.path + '/images/learn/ni-added.svg"/>';
+                    }
+                    link += ': </a>';
+
+                    return link;
+                }
+            }
     ),
 
     initComponent : function() {

--- a/webapp/production/Connector/resources/images/learn/ni-added.svg
+++ b/webapp/production/Connector/resources/images/learn/ni-added.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="36px" height="36px" viewBox="0 0 36 36" version="1.1">
+    <title>Icon / Data Availability / Non-integrated / Available</title>
+    <g id="Icon-/-Data-Availability-/-Non-integrated-/-Available" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <polygon id="Path" fill="#00C89D" points="8.67687127 17.8471526 15.7339748 24.9042561 27.4595859 13.178645 25.1237803 10.8428393 15.7339748 20.2326448 11.1657977 15.3521819"/>
+        <path d="M18,0 C27.9411255,0 36,8.0588745 36,18 C36,27.9411255 27.9411255,36 18,36 C8.0588745,36 0,27.9411255 0,18 C0,8.0588745 8.0588745,0 18,0 Z M18,3 C9.71572875,3 3,9.71572875 3,18 C3,26.2842712 9.71572875,33 18,33 C26.2842712,33 33,26.2842712 33,18 C33,9.71572875 26.2842712,3 18,3 Z" id="Oval-Copy" fill="#00C89D" fill-rule="nonzero"/>
+    </g>
+</svg>


### PR DESCRIPTION
#### Rationale
This PR will display the data availability status for publication data in the following views:
- Add indicators to the learn about/publications page to show whether data is available or not for the specific publication.
- Add the data availability indicator in the publications section of the study  details page.

More details in this spec:
- https://docs.google.com/document/d/1rkV5I94BwgaUj0V0bpzBvTmyocL7cv2PLJ4SBq1rG3E/edit

#### Changes
- Add a data availability column in the publications learn page
- Display a data availability indicator on the study details page for the publications section
- Update the learn_publicationsforstudies query to include the data available count for a given publication
