### PR TITLE
Test fix for CDSVisualizationPlotTest.verifyAntigenBoxPlot

### DIFF
--- a/test/src/org/labkey/test/tests/cds/CDSVisualizationPlotTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSVisualizationPlotTest.java
@@ -445,7 +445,9 @@ public class CDSVisualizationPlotTest extends CDSReadOnlyTest
 
         log("Counting '" + uniqueVirus + "' in tier_clade_virus & virus_full_name cols.");
         assertEquals(200, Locator.tagContainingText("td", uniqueVirus).findElements(getDriver()).size());
-        assertTextNotPresent(sharedVirus, CDSHelper.LABS[1]);
+        assertTextNotPresent(sharedVirus);
+        plotDataTable.setFilter("study_NAb_lab_code", "Equals", CDSHelper.LABS[1]);
+        assertEquals("WA should not be present in the lab codes", 0, plotDataTable.getDataRowCount());
         getDriver().close();
         switchToMainWindow();
 


### PR DESCRIPTION
#### Rationale
Test fix by changing the assertTextNotPresent  to actually verifying against the lab code not present in the table.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
test/src/org/labkey/test/tests/cds/CDSVisualizationPlotTest.java
