### PR TITLE
Study Description tooltip iteration

### DIFF
--- a/webapp/Connector/src/app/view/module/DataAvailabilityModule.js
+++ b/webapp/Connector/src/app/view/module/DataAvailabilityModule.js
@@ -103,6 +103,7 @@ Ext.define('Connector.view.module.DataAvailabilityModule', {
                                 && textRect.left <= cursorX && cursorX <= textRect.right) {
                             this.showDataStatusTooltip(evt, dataLink.dom, {
                                 status: record.data.has_data ? (record.data.has_access ? toolTipMsg_available : toolTipMsg_restricted) : toolTipMsg_notAdded,
+                                description: record.data.data_description,
                                 id: id
                             });
                         }

--- a/webapp/Connector/src/view/InfoPane.js
+++ b/webapp/Connector/src/view/InfoPane.js
@@ -625,10 +625,25 @@ Ext.define('Connector.view.InfoPane', {
                 var calloutMgr = hopscotch.getCalloutManager(),
                         _id = el.id,
                         displayTooltip = setTimeout(function() {
+                            // compute the callout height based on approximately 35 chars per line (plus margin)
+                            var lines = rec.data.description.length / 35;
+                            var calloutHeight = 30 + (17 * lines);
+
+                            // shift the y-offset of the callout if it is larger than the 50 pixel margin we
+                            // have at the bottom of the info pane
+                            if (calloutHeight > 50) {
+                                verticalOffset = calloutHeight - 35;
+                                arrowOffset = verticalOffset - 14;
+                            } else {
+                                verticalOffset = calloutHeight / 2;
+                                arrowOffset = 0;
+                            }
+
                             calloutMgr.createCallout(Ext.apply({
                                 id: _id,
                                 xOffset: -30,
-                                yOffset: -20,
+                                yOffset: -verticalOffset,
+                                arrowOffset: arrowOffset,
                                 showCloseButton: false,
                                 target: highlighted[0],
                                 placement: 'left',

--- a/webapp/Connector/src/view/Learn.js
+++ b/webapp/Connector/src/view/Learn.js
@@ -498,6 +498,7 @@ Ext.define('Connector.view.Learn', {
                     store = StoreCache.getStore(dimension.detailCollection);
 
                     this.add(Ext.create(dimension.detailView, {
+                        padding : '2 0 0 0',
                         itemId: listId,
                         dimension: dimension,
                         store: store,

--- a/webapp/Connector/src/view/SingleAxisExplorer.js
+++ b/webapp/Connector/src/view/SingleAxisExplorer.js
@@ -203,7 +203,7 @@ Ext.define('Connector.view.SingleAxisExplorer', {
             if (el) {
                 var calloutMgr = hopscotch.getCalloutManager();
                 var id = el.id;
-                var tooltip = this.getTooltip(rec.data.hierarchy, name);
+                var tooltip = this.getTooltip(rec.data.levelUniqueName, name);
 
                 if (tooltip) {
                     var displayTooltip = setTimeout(function() {
@@ -233,20 +233,28 @@ Ext.define('Connector.view.SingleAxisExplorer', {
     },
 
     parseExplorerBarName : function(hierarchy, uniqueName) {
-        // for now only support studies and treatment arms
-        if (hierarchy === '[Study.Treatment]' || hierarchy === '[Assay.Study]') {
+        if (hierarchy.startsWith('[Study.') || hierarchy.startsWith('[Assay.Study]')) {
             var parts = uniqueName.split('\.');
-            if (parts.length === 4) {
-                return parts[3].substr(1, parts[3].length-2);
-            }
+            var num = parts.length;
+
+            return parts[num-1].substr(1, parts[num-1].length-2);
         }
     },
 
-    getTooltip : function(hierarchy, label) {
-        if (hierarchy === '[Study.Treatment]')
-            return StudyUtils.getTreatmentArmDescription(label);
-        else if (hierarchy === '[Assay.Study]')
-            return StudyUtils.getStudyDescription(label);
+    getTooltip : function(level, label) {
+
+        switch (level) {
+            case '[Study.Treatment].[Arm]' :
+                return StudyUtils.getTreatmentArmDescription(label);
+            case '[Study.Treatment].[Treatment]' :
+            case '[Study.Treatment Arm Coded Label].[Name]' :
+            case '[Study.Type].[Name]' :
+            case '[Study.Network].[Name]' :
+            case '[Study.Strategy].[Name]' :
+            case '[Study.PI].[Name]' :
+            case '[Assay.Study].[Study]' :
+                return StudyUtils.getStudyDescription(label);
+        }
     },
 
     onFilterChange : function() {
@@ -511,7 +519,7 @@ Ext.define('Connector.view.SingleAxisExplorerView', {
             '</div>',
             '</tpl>',
             '<div class="', this.barCls, ' large">',
-            '<span class="', this.barLabelCls, '">{label:htmlEncode}',
+            '<span class="', this.barLabelCls, '" uniquename="{uniqueName:htmlEncode}">{label:htmlEncode}',
             (this.ordinal ? '&nbsp;({ordinal:htmlEncode})' : ''),
             '</span>',
             '{[ this.renderCount(values) ]}',


### PR DESCRIPTION
#### Rationale
This is a follow on story to address a few issues discovered with the initial work as well as implementing the study description tooltips in some additional areas of the app:

https://www.labkey.org/Dataspace/Feature%20Requests/issues-details.view?issueId=36302
https://www.labkey.org/Dataspace/Support%20Tickets/issues-details.view?issueId=43879

#### Changes
- The tooltip on the active filters panel can be truncated for long descriptions at the bottom of the filter panel
- The study description is sometimes not shown in the data availability tooltip
- The magenta underline indicating the current learn topic selected can be obscured by the learn grid column highlight or selection
- Add additional study description tooltips for the single axis explorer bars (find)
  - Treatment Summary -> Study Names on Page
  - Treatment Arm Coded Label -> Study Names on Page
  - Study Type -> Expand Types -> Study Names in Expanded Type
  - Network -> Expand Network -> Study Names in Expanded Network
  - PI -> Expand PI -> Study Names in Expanded PI
 -> Strategy -> Expand Strategy -> Study Names in Expanded Strategy

