### PR TITLE
21.11 fb data added filter

### DIFF
--- a/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
+++ b/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
@@ -1578,14 +1578,13 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
         log("Evaluating applying two numeric filters");
         //finds the number of rows that have a date column and assay column that satisfy the following filter
         final String yearToFilter = "2004";
-        final String numAssaysToFilter = "1";
         int numRowsSatisfyFilter = Locator.xpath("//tr/td/div/div/div[contains(@class, 'detail-gray-text')]" +
-                "[contains(text(), '" + numAssaysToFilter + " Integrated Assay')]/../../../following-sibling::" +
+                "[contains(text(), ' Integrated Assay')]/../../../following-sibling::" +
                 "td/div/div/table/tbody/tr[contains(@class, 'detail-gray-text')]/td[contains(text(), '"+ yearToFilter + "')]")
                 .findElements(getDriver()).size();
 
         learnGrid.setWithOptionFacet("Status", "Start Year", yearToFilter);
-        learnGrid.setFacet("Data Added", numAssaysToFilter);
+        learnGrid.setFacet("Data Added", "Integrated data");
         numRowsPostFilter = learnGrid.getRowCount();
 
         assertTrue(numRowsSatisfyFilter == numRowsPostFilter);
@@ -1760,7 +1759,7 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
         assertTrue(2 == learnGrid.getRowCount());
 
         //Test combining filter with another column
-        learnGrid.setFacet("Data Added", "2");
+        learnGrid.setFacet("Data Added", "Data not added");
         _asserts.verifyEmptyLearnAboutStudyPage();
 
         //clear all filters and check results are correct in succession.

--- a/webapp/Connector/src/app/model/Assay.js
+++ b/webapp/Connector/src/app/model/Assay.js
@@ -41,6 +41,7 @@ Ext.define('Connector.app.model.Assay', {
         {name: 'hasAntigen'},
         {name: 'assayTutorialDocuments'},
         {name: 'assayTutorialLinks'},
-        {name: 'interactive_reports', convert : Connector.model.Filter.asArray}
+        {name: 'interactive_reports', convert : Connector.model.Filter.asArray},
+        {name: 'data_types_available', convert : Connector.model.Filter.asArray}
     ]
 });

--- a/webapp/Connector/src/app/model/MAb.js
+++ b/webapp/Connector/src/app/model/MAb.js
@@ -46,6 +46,7 @@ Ext.define('Connector.app.model.MAb', {
         {name: 'data_accessible'},
         {name: 'studies_with_data_count'},
         {name: 'studies', convert : Connector.model.Filter.asArray},
-        {name: 'studies_with_data', convert : Connector.model.Filter.asArray}
+        {name: 'studies_with_data', convert : Connector.model.Filter.asArray},
+        {name: 'data_types_available', convert : Connector.model.Filter.asArray}
     ]
 });

--- a/webapp/Connector/src/app/model/Publication.js
+++ b/webapp/Connector/src/app/model/Publication.js
@@ -37,6 +37,7 @@ Ext.define('Connector.app.model.Publication', {
         {name: 'study_names', convert : Connector.model.Filter.asArray},
         {name: 'studies', convert : Connector.model.Filter.asArray},
         {name: 'interactive_reports', convert : Connector.model.Filter.asArray},
-        {name: 'curated_groups', convert : Connector.model.Filter.asArray}
+        {name: 'curated_groups', convert : Connector.model.Filter.asArray},
+        {name: 'data_types_available', convert : Connector.model.Filter.asArray}
     ]
 });

--- a/webapp/Connector/src/app/model/Study.js
+++ b/webapp/Connector/src/app/model/Study.js
@@ -121,6 +121,8 @@ Ext.define('Connector.app.model.Study', {
         {name: 'specimen_repository_label'},
         {name: 'monoclonal_antibodies', convert : Connector.model.Filter.asArray},
         {name: 'interactive_reports', convert : Connector.model.Filter.asArray},
-        {name: 'curated_groups', convert : Connector.model.Filter.asArray}
+        {name: 'curated_groups', convert : Connector.model.Filter.asArray},
+        {name: 'data_types_available', convert : Connector.model.Filter.asArray},
+        {name: 'data_available'}
     ]
 });

--- a/webapp/Connector/src/app/model/StudyProducts.js
+++ b/webapp/Connector/src/app/model/StudyProducts.js
@@ -47,6 +47,7 @@ Ext.define('Connector.app.model.StudyProducts', {
         {name: 'studies_with_data_count'},
         {name: 'studies', convert : Connector.model.Filter.asArray},
         {name: 'other_products', convert : Connector.model.Filter.asArray},
-        {name: 'studies_with_data', convert : Connector.model.Filter.asArray}
+        {name: 'studies_with_data', convert : Connector.model.Filter.asArray},
+        {name: 'data_types_available', convert : Connector.model.Filter.asArray}
     ]
 });

--- a/webapp/Connector/src/app/store/Assay.js
+++ b/webapp/Connector/src/app/store/Assay.js
@@ -187,6 +187,8 @@ Ext.define('Connector.app.store.Assay', {
                 if (interactiveReports && interactiveReports.length > 0) {
                     assay.interactive_reports = interactiveReports;
                 }
+                assay.data_types_available = this.getDataTypesAvailable(assay);
+
                 assays.push(assay);
             }, this);
 

--- a/webapp/Connector/src/app/store/MAb.js
+++ b/webapp/Connector/src/app/store/MAb.js
@@ -4,7 +4,8 @@
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
 Ext.define('Connector.app.store.MAb', {
-    extend : 'Ext.data.Store',
+
+    extend : 'Connector.app.store.SavedReports',
 
     statics: {
         LANL_URL_PREFIX: 'https://www.hiv.lanl.gov/content/immunology/ab_search?results=Search&id='
@@ -199,6 +200,7 @@ Ext.define('Connector.app.store.MAb', {
                 mixRec.studies = studies;
                 mixRec.studies_with_data = studiesWithData;
                 mixRec.studies_with_data_count = studiesWithData.length;
+                mixRec.data_types_available = this.getDataTypesAvailable(mixRec);
 
                 mixRecs.push(mixRec);
             }, this);

--- a/webapp/Connector/src/app/store/Publication.js
+++ b/webapp/Connector/src/app/store/Publication.js
@@ -273,5 +273,20 @@ Ext.define('Connector.app.store.Publication', {
             this.dataLoaded = true;
             LABKEY.Utils.signalWebDriverTest("learnPublicationsLoaded");
         }
+    },
+
+    /**
+     * Override since publications has a slightly different notion of available data types (than study)
+     */
+    getDataTypesAvailable: function (rec) {
+        var available_data_types = [];
+        if (rec.data_availability)
+            available_data_types.push('Publication data');
+        if (rec.ni_data_availability)
+            available_data_types.push('Non-integrated data');
+        if (available_data_types.length === 0)
+            available_data_types.push('Data not added');
+
+        return available_data_types;
     }
 });

--- a/webapp/Connector/src/app/store/Publication.js
+++ b/webapp/Connector/src/app/store/Publication.js
@@ -4,6 +4,7 @@
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
 Ext.define('Connector.app.store.Publication', {
+
     extend : 'Connector.app.store.SavedReports',
 
     mixins: {
@@ -254,9 +255,10 @@ Ext.define('Connector.app.store.Publication', {
                 if (curatedGrp && curatedGrp.length > 0) {
                     publication.curated_groups = curatedGrp;
                 }
+                publication.data_types_available = this.getDataTypesAvailable(publication);
 
                 publications.push(publication);
-            });
+            }, this);
 
 
             this.publicationData = undefined;

--- a/webapp/Connector/src/app/store/SavedReports.js
+++ b/webapp/Connector/src/app/store/SavedReports.js
@@ -41,7 +41,27 @@ Ext.define('Connector.app.store.SavedReports', {
         this._onLoadComplete();
     },
 
-    _onLoadComplete : function() {
+    _onLoadComplete: function () {
         // override and implement
+    },
+
+    getDataTypesAvailable: function (rec) {
+        var available_data_types = [];
+        if (rec.data_availability)
+            available_data_types.push('Integrated data');
+        if (rec.ni_data_availability)
+            available_data_types.push('Non-integrated data');
+
+        if (rec.publications) {
+            var pubDataAvailable = rec.publications.filter(function (pub) {
+                return pub.available_data_count > 0;
+            })
+            if (pubDataAvailable.length > 0)
+                available_data_types.push('Publication data');
+        }
+        if (available_data_types.length === 0)
+            available_data_types.push('Data not added');
+
+        return available_data_types;
     }
 });

--- a/webapp/Connector/src/app/store/Study.js
+++ b/webapp/Connector/src/app/store/Study.js
@@ -534,6 +534,8 @@ Ext.define('Connector.app.store.Study', {
                     return pub.available_data_count > 0;
                 })
                 study.pub_available_data_count = pubDataAvailable.length;
+                study.data_types_available = this.getDataTypesAvailable(study);
+                study.data_available = (study.assays_added_count > 0 || study.ni_assays_added_count > 0 || study.pub_available_data_count > 0) ? 'Data added' : 'Data not added';
 
                 studies.push(study);
             }, this);

--- a/webapp/Connector/src/app/store/StudyProducts.js
+++ b/webapp/Connector/src/app/store/StudyProducts.js
@@ -5,7 +5,7 @@
  */
 Ext.define('Connector.app.store.StudyProducts', {
 
-    extend : 'Ext.data.Store',
+    extend : 'Connector.app.store.SavedReports',
 
     mixins: {
         studyAccessHelper: 'Connector.app.store.PermissionedStudy'
@@ -213,6 +213,7 @@ Ext.define('Connector.app.store.StudyProducts', {
                     });
                 }
                 product.other_products = otherProducts;
+                product.data_types_available = this.getDataTypesAvailable(product);
 
                 if (!this.hiddenProduct(product.product_name)) {
                     products.push(product);

--- a/webapp/Connector/src/app/view/Assay.js
+++ b/webapp/Connector/src/app/view/Assay.js
@@ -44,9 +44,9 @@ Ext.define('Connector.app.view.Assay', {
         resizable: false,
         dataIndex: 'studies_with_data_count',
         filterConfigSet: [{
-            filterField: 'studies_with_data_count',
-            valueType: 'number',
-            title: '# of Studies Added'
+            filterField: 'data_types_available',
+            valueType: 'string',
+            title: 'Data Types Available'
         }],
         tpl: new Ext.XTemplate(
                 '<div class="detail-text">',

--- a/webapp/Connector/src/app/view/MAb.js
+++ b/webapp/Connector/src/app/view/MAb.js
@@ -44,9 +44,9 @@ Ext.define('Connector.app.view.MAb', {
             resizable: false,
             dataIndex: 'studies_with_data_count',
             filterConfigSet: [{
-                filterField: 'studies_with_data_count',
-                valueType: 'number',
-                title: '# of Studies Added'
+                filterField: 'data_types_available',
+                valueType: 'string',
+                title: 'Data Types Available'
             }],
             tpl: new Ext.XTemplate(
                     '<div class="detail-text">',

--- a/webapp/Connector/src/app/view/Publication.js
+++ b/webapp/Connector/src/app/view/Publication.js
@@ -46,9 +46,9 @@ Ext.define('Connector.app.view.Publication', {
             resizable: false,
             dataIndex: 'publication_data',
             filterConfigSet: [{
-                filterField: 'publication_data_count',
-                valueType: 'number',
-                title: 'publication data count'
+                filterField: 'data_types_available',
+                valueType: 'string',
+                title: 'Data Types Available'
             }],
             tpl: new Ext.XTemplate(
                 '<div class="detail-text">',

--- a/webapp/Connector/src/app/view/Study.js
+++ b/webapp/Connector/src/app/view/Study.js
@@ -45,9 +45,13 @@ Ext.define('Connector.app.view.Study', {
         resizable: false,
         dataIndex: 'assays_added_count',
         filterConfigSet: [{
-            filterField: 'assays_added_count',
-            valueType: 'number',
-            title: '# of Assays Added'
+            filterField: 'data_types_available',
+            valueType: 'string',
+            title: 'Data Types Available'
+        },{
+            filterField: 'data_available',
+            valueType: 'string',
+            title: 'Data Available'
         }],
         tpl: new Ext.XTemplate(
                 '<div class="detail-text">',

--- a/webapp/Connector/src/app/view/StudyProducts.js
+++ b/webapp/Connector/src/app/view/StudyProducts.js
@@ -45,9 +45,9 @@ Ext.define('Connector.app.view.StudyProducts', {
         resizable: false,
         dataIndex: 'studies_with_data_count',
         filterConfigSet: [{
-            filterField: 'studies_with_data_count',
-            valueType: 'number',
-            title: '# of Studies Added'
+            filterField: 'data_types_available',
+            valueType: 'string',
+            title: 'Data Types Available'
         }],
         tpl: new Ext.XTemplate(
                 '<div class="detail-text">',


### PR DESCRIPTION
#### Rationale
Now that we have the publication data and non-integrated data availability implemented, we should consider updating the Data Added column filter. Currently, the user selects a number from a list (i.e. the number of assays). This has always been a little awkward and it doesn't account for publication or non-integrated data.

Associated feature request:
- https://www.labkey.org/Dataspace/Feature%20Requests/issues-details.view?issueId=43741

#### Changes
Instead of showing the data availability counts in the filter, we will display the following options for each learn page:
- Study : data types available (integrated, non-integrated, publication, none) and data available (data added, data not added)
- Assay : data types available
- Products : data types available
- MAbs : data types available
- Publications : data types available