### PR TITLE
Address GroupTest Failures in CDS

### DIFF
--- a/test/src/org/labkey/test/tests/cds/CDSGroupBaseTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSGroupBaseTest.java
@@ -15,12 +15,12 @@
  */
 package org.labkey.test.tests.cds;
 
-import org.junit.Test;
 import org.labkey.test.Locator;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.cds.CDSAsserts;
 import org.labkey.test.util.cds.CDSHelper;
+import org.openqa.selenium.WebElement;
 
 import java.util.Arrays;
 import java.util.List;
@@ -143,9 +143,10 @@ public abstract class CDSGroupBaseTest extends CDSReadOnlyTest
         _ext4Helper.waitForMaskToDisappear();
 
         log("Verify that reader cannot delete");
-        click(CDSHelper.Locators.cdsButtonLocator("Delete"));
+
+        CDSHelper.Locators.cdsHeaderButtonLocator("Delete").findElement(getDriver()).click();
         waitForText("Are you sure you want to delete");
-        click(CDSHelper.Locators.cdsButtonLocator("Delete", "x-toolbar-item").notHidden());
+        CDSHelper.Locators.cdsButtonLocator("Delete", "x-toolbar-item").notHidden().findElement(getDriver()).click();
         waitForText("ERROR");
         click(CDSHelper.Locators.cdsButtonLocator("OK", "x-toolbar-item").notHidden());
 
@@ -165,9 +166,9 @@ public abstract class CDSGroupBaseTest extends CDSReadOnlyTest
         //delete group
         click(sharedGroupLoc);
         waitForText("Edit details");
-        click(CDSHelper.Locators.cdsButtonLocator("Delete"));
+        CDSHelper.Locators.cdsHeaderButtonLocator("Delete").findElement(getDriver()).click();
         waitForText("Are you sure you want to delete");
-        click(CDSHelper.Locators.cdsButtonLocator("Delete", "x-toolbar-item").notHidden());
+        CDSHelper.Locators.cdsButtonLocator("Delete", "x-toolbar-item").notHidden().findElement(getDriver()).click();
         waitForText("Getting Started");
         refresh();
         scrollIntoView(Locator.tagWithClass("h2", "section-title"));
@@ -218,6 +219,23 @@ public abstract class CDSGroupBaseTest extends CDSReadOnlyTest
         action.run();
         Ext4Helper.setCssPrefix("x-");
         cds.enterApplication();
+    }
+
+    protected void clickGroupLabelOnHomePage(String groupLabel)
+    {
+        String currentUrl = getCurrentRelativeURL();
+        assertTrue("Not on the CDS home page.", currentUrl.toLowerCase().contains("#home"));
+
+        WebElement groupListElement = Locator.tagWithClass("div", "grouplist-view").refindWhenNeeded(getDriver());
+        waitFor(groupListElement::isDisplayed, "GroupList was not visible.", 1_000);
+
+        WebElement groupLabelElement = Locator.tagWithClass("div", "grouplabel").withText(groupLabel).findWhenNeeded(groupListElement);
+        waitFor(groupLabelElement::isDisplayed, String.format("Group with label '%s' is not visible.", groupLabel), 1_000);
+
+        groupLabelElement.click();
+
+        waitFor(()->getCurrentRelativeURL().toLowerCase().contains("group/groupsummary"),
+                String.format("Click group label '%s' did not navigate.", groupLabel), 1_000);
     }
 
 }

--- a/test/src/org/labkey/test/tests/cds/CDSGroupTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSGroupTest.java
@@ -183,14 +183,14 @@ public class CDSGroupTest extends CDSGroupBaseTest
         _asserts.assertFilterStatusCounts(89, 2, 1, 3, 7); // TODO Test data dependent.
 
         CDSHelper.NavigationLink.HOME.makeNavigationSelection(this);
-        waitForText(STUDY_GROUP);
-        click(Locator.tagWithClass("div", "grouplabel").withText(STUDY_GROUP));
+        clickGroupLabelOnHomePage(STUDY_GROUP);
 
         // Verify that the description has changed.
         waitForText(studyGroupDescModified);
 
         // Verify that No plot data message is shown
-        assertTextPresent("No plot saved for this group.");
+        waitFor(()->isElementPresent(Locator.tagContainingText("h3", "No plot saved for this group.")),
+                "'No plot saved for this group' message was not present.", 1_5000);
 
         // verify 'whoops' case
         click(CDSHelper.Locators.cdsButtonLocator("save", "filtersave"));
@@ -206,8 +206,8 @@ public class CDSGroupTest extends CDSGroupBaseTest
         _asserts.assertFilterStatusCounts(1604, 14, 2, 3, 91); // TODO Test data dependent.
 
         CDSHelper.NavigationLink.HOME.makeNavigationSelection(this);
-        waitForText(STUDY_GROUP);
-        click(Locator.tagWithClass("div", "grouplabel").withText(STUDY_GROUP));
+
+        clickGroupLabelOnHomePage(STUDY_GROUP);
 
         // Verify the group does overwrite already active filters
         sleep(500); // give it a chance to apply
@@ -216,8 +216,7 @@ public class CDSGroupTest extends CDSGroupBaseTest
 
         // Verify the filters get applied when directly acting
         CDSHelper.NavigationLink.HOME.makeNavigationSelection(this);
-        waitForText(STUDY_GROUP);
-        click(Locator.tagWithClass("div", "grouplabel").withText(STUDY_GROUP));
+        clickGroupLabelOnHomePage(STUDY_GROUP);
         waitForElement(CDSHelper.Locators.filterMemberLocator(CDSHelper.STUDIES[0]));
         assertElementNotPresent(CDSHelper.Locators.filterMemberLocator(CDSHelper.ASSAYS[1]));
         _asserts.assertFilterStatusCounts(89, 2, 1, 3, 7); // TODO Test data dependent.
@@ -247,8 +246,6 @@ public class CDSGroupTest extends CDSGroupBaseTest
     {
         String singleFilterGroup = "cds_single_group";
         String multiFilterGroup = "cds_multi_group";
-        Locator.XPathLocator singleLoc = CDSHelper.Locators.getPrivateGroupLoc(singleFilterGroup);
-        Locator.XPathLocator multiLoc = CDSHelper.Locators.getPrivateGroupLoc(multiFilterGroup);
 
         log("Compose a group that consist of a single filter");
         cds.goToSummary();
@@ -271,14 +268,14 @@ public class CDSGroupTest extends CDSGroupBaseTest
         cds.saveGroup(multiFilterGroup, "", false);
 
         CDSHelper.NavigationLink.HOME.makeNavigationSelection(this);
-        click(singleLoc);
+        clickGroupLabelOnHomePage(singleFilterGroup);
         sleep(2000); // wait for filter panel to stablize
         log("Verify the group consist of a single filter is applied correctly");
         List<WebElement> activeFilters = cds.getActiveFilters();
         assertEquals("Number of active filters not as expected.", 1, activeFilters.size());
 
         CDSHelper.NavigationLink.HOME.makeNavigationSelection(this);
-        click(multiLoc);
+        clickGroupLabelOnHomePage(multiFilterGroup);
         sleep(2000); // wait for filter panel to stablize
         log("Verify the group consist of a 4 filters is applied correctly when current filter panel contains only one filter");
         activeFilters = cds.getActiveFilters();
@@ -286,7 +283,7 @@ public class CDSGroupTest extends CDSGroupBaseTest
 
 
         CDSHelper.NavigationLink.HOME.makeNavigationSelection(this);
-        click(singleLoc);
+        clickGroupLabelOnHomePage(singleFilterGroup);
         sleep(2000); // wait for filter panel to stablize
         log("Verify the group consist of a single filter is applied correctly when current filter panel contains 4 filters");
         activeFilters = cds.getActiveFilters();
@@ -328,8 +325,7 @@ public class CDSGroupTest extends CDSGroupBaseTest
         cds.clearFilters(true);
 
         CDSHelper.NavigationLink.HOME.makeNavigationSelection(this);
-        waitForText(GROUP_PLOT_TEST);
-        click(Locator.tagWithClass("div", "grouplabel").withText(GROUP_PLOT_TEST));
+        clickGroupLabelOnHomePage(GROUP_PLOT_TEST);
         waitForText("View in Plot");
         click(Locator.xpath("//span/following::span[contains(text(), 'View in Plot')]").parent().parent().parent());
         assertTrue(getDriver().getCurrentUrl().contains("#chart"));
@@ -364,8 +360,7 @@ public class CDSGroupTest extends CDSGroupBaseTest
         cds.saveGroup(STUDY_GROUP_Q2, studyGroupDesc, true);
 
         cds.goToAppHome();
-        Locator.XPathLocator listGroup = Locator.tagWithClass("div", "grouplabel");
-        waitAndClick(listGroup.withText(STUDY_GROUP_Q2));
+        clickGroupLabelOnHomePage(STUDY_GROUP_Q2);
         String groupUrl = getCurrentRelativeURL();
         String[] vals = groupUrl.split("/");
         int rowId = Integer.valueOf(vals[vals.length - 1]); //study.SubjectGroup.RowId
@@ -389,7 +384,7 @@ public class CDSGroupTest extends CDSGroupBaseTest
         cds.saveGroup(STUDY_GROUP_Z110, studyGroupDesc2, false);
 
         cds.goToAppHome();
-        waitAndClick(listGroup.withText(STUDY_GROUP_Z110));
+        clickGroupLabelOnHomePage(STUDY_GROUP_Z110);
         groupUrl = getCurrentRelativeURL();
         vals = groupUrl.split("/");
         rowId = Integer.valueOf(vals[vals.length - 1]); //study.SubjectGroup.RowId
@@ -483,9 +478,13 @@ public class CDSGroupTest extends CDSGroupBaseTest
     {
         log("Verifying links of assay page");
         goToAssayPage(CDSHelper.TITLE_ICS);
-        waitForElementWithRefresh(Locator.id("interactive_report_title"), 5000);
+
+        WebElement reportTitleElement = Locator.id("interactive_report_title").refindWhenNeeded(getDriver());
+
+        waitFor(reportTitleElement::isDisplayed, "Report title was not displayed.", 5_000);
+
         log("verify interactive report link");
-        scrollIntoView(Locator.id("interactive_report_title"));
+        scrollIntoView(reportTitleElement);
 
         log("Verifying report is present");
         assertElementPresent(Locator.linkWithText(reportName));
@@ -495,7 +494,7 @@ public class CDSGroupTest extends CDSGroupBaseTest
     {
         goToProjectHome();
         clickTab("Clinical and Assay Data");
-        clickAndWait(Locator.linkWithText(reportName));
+        waitAndClickAndWait(Locator.linkWithText(reportName));
         int reportNum = cds.getReportNumberFromUrl(getDriver().getCurrentUrl());
         goToSchemaBrowser();
         DataRegionTable table = ExecuteQueryPage.beginAt(this, "CDS", "assayReport").getDataRegion();
@@ -620,8 +619,7 @@ public class CDSGroupTest extends CDSGroupBaseTest
         log("Go back to the CDS portal, load the group, and validate the expected error message is shown.");
         cds.enterApplication();
 
-        waitForElement(Locator.tagWithClass("div", "grouplabel").withText(GROUP_NAME));
-        click(Locator.tagWithClass("div", "grouplabel").withText(GROUP_NAME));
+        clickGroupLabelOnHomePage(GROUP_NAME);
 
         log("Validate that the error message box is shown.");
         waitForElementToBeVisible(Locator.tagWithClassContaining("div", "x-message-box"));
@@ -653,8 +651,8 @@ public class CDSGroupTest extends CDSGroupBaseTest
         log("Go back to the CDS portal, load the group, and validate no error is shown and the filter is applied.");
         cds.enterApplication();
 
-        waitForElement(Locator.tagWithClass("div", "grouplabel").withText(GROUP_NAME));
-        click(Locator.tagWithClass("div", "grouplabel").withText(GROUP_NAME));
+        clickGroupLabelOnHomePage(GROUP_NAME);
+
         waitForText("No plot saved for this group.");
         _ext4Helper.waitForMaskToDisappear();
 

--- a/test/src/org/labkey/test/tests/cds/CDSReadOnlyTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSReadOnlyTest.java
@@ -19,13 +19,12 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PostgresOnlyTest;
 import org.labkey.test.util.ReadOnlyTest;
-import org.labkey.test.util.cds.CDSHelper;
 import org.labkey.test.util.cds.CDSInitializer;
-import org.openqa.selenium.NoSuchElementException;
 
 import java.util.Arrays;
 import java.util.List;
@@ -65,15 +64,13 @@ public class CDSReadOnlyTest extends BaseWebDriverTest implements ReadOnlyTest, 
     @Override
     public boolean needsSetup()
     {
-        try
-        {
-            new CDSHelper(this).beginAtApplication(getProjectName());
+        goToHome();
+
+        // If a link to the project is present on the server home page, no set-up is needed.
+        if(isElementPresent(Locator.linkContainingText(getProjectName())))
             return false;
-        }
-        catch (NoSuchElementException | AssertionError e)
-        {
+        else
             return true;
-        }
     }
 
     @Before

--- a/test/src/org/labkey/test/util/cds/CDSHelper.java
+++ b/test/src/org/labkey/test/util/cds/CDSHelper.java
@@ -34,8 +34,8 @@ import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.PermissionsHelper;
 import org.labkey.test.util.RReportHelper;
-import org.labkey.test.util.TestLogger;
 import org.labkey.test.util.UIPermissionsHelper;
+import org.labkey.test.util.URLBuilder;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Keys;
@@ -715,18 +715,22 @@ public class CDSHelper
     @LogMethod(quiet = true)
     public void enterApplication()
     {
-        _test.refresh();
-        BaseWebDriverTest.sleep(2000);
         _test.goToProjectHome();
-        _test.clickAndWait(Locator.linkWithText("Application"), 10000);
-        _test.addUrlParameter("logQuery=1&_showPlotData=true&_disableAutoMsg=true");
-
-        afterInApplication();
+        beginAtApplication(_test.getCurrentProject());
     }
 
     public void beginAtApplication(String projectName)
     {
-        _test.beginAt(WebTestHelper.buildURL("cds", projectName, "app", Map.of("logQuery", "1", "_showPlotData", "true", "_disableAutoMsg", "true")));
+
+        String currentUrl = _test.getCurrentRelativeURL().toLowerCase();
+
+        // If the url does not contain any one of these three items then navigate.
+        if(!currentUrl.contains(projectName) || !currentUrl.contains("cds-app.view") || !currentUrl.contains("#home"))
+        {
+            String url = String.format("%s#Home",
+                    WebTestHelper.buildURL("cds", projectName, "app", Map.of("logQuery", "1", "_showPlotData", "true", "_disableAutoMsg", "true")));
+            _test.beginAt(url);
+        }
         afterInApplication();
     }
 
@@ -1807,6 +1811,11 @@ public class CDSHelper
                     (isShared ? "Curated groups and plots" : "My saved groups and plots") + "')]" +
                     "/following::div[contains(@class, 'grouprow')]/div[contains(text(), '" +
                     groupName + "')]");
+        }
+
+        public static Locator.XPathLocator cdsHeaderButtonLocator(String text)
+        {
+            return Locator.xpath("//div[contains(@class,'pageheader')]//a[not(contains(@style, 'display: none'))]").withPredicate(Locator.xpath("//span[contains(@class, 'x-btn-inner') and text()='" + text + "']"));
         }
 
         public static Locator.XPathLocator cdsButtonLocator(String text)


### PR DESCRIPTION
#### Rationale
Trying to address some of the failures in the groupTest in CDS. The test is having a hard time finding the right (visible) element.

#### Related Pull Requests
* None

#### Changes
* Try to use better locators and element finders in CDSGroups tests.Add better wait for pages and elements in CDSGroups tests.
* Improve check for needsSetup.
* Change enterApplication to use beginAtApplication.
