### PR TITLE
44631: Study page - link to publication data not complete

### DIFF
--- a/webapp/Connector/src/app/view/module/StudyPublications.js
+++ b/webapp/Connector/src/app/view/module/StudyPublications.js
@@ -69,7 +69,7 @@ Ext.define('Connector.view.module.StudyPublications', {
                                     '<tr>',
                                         '<td class="item-value">',
                                         '<tpl if="label">',
-                                            '<a href="#learn/learn/Publication/{id}">{label:htmlEncode}: </a>',
+                                            '{[this.getPublicationLink(values)]}',
                                         '</tpl>',
                                         '{authors:htmlEncode}. {title:htmlEncode}. {journal:htmlEncode}. {date:htmlEncode}',
                                         '<tpl if="volume || issue">',


### PR DESCRIPTION
#### Rationale
Minor fix for the data availability icon not displaying in study publications that were not initially shown on the page because it exceeded the configured limit of 10. We just missed adding the call to `getPublicationLink` during the initial development (on the other side of the if clause).

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44631
