### PR TITLE
Updates to data export button. (archived in SC)

### DIFF
--- a/src/org/labkey/cds/view/template/ConnectorTemplate.jsp
+++ b/src/org/labkey/cds/view/template/ConnectorTemplate.jsp
@@ -188,6 +188,7 @@
             // Application source
             srcPath + "/button/Image.js",
             srcPath + "/button/RoundedButton.js",
+            srcPath + "/button/Export.js",
             srcPath + "/component/ActionTitle.js",
             srcPath + "/component/AdvancedOption.js",
             srcPath + "/component/AbstractAntigenSelection.js",

--- a/test/src/org/labkey/test/pages/cds/DataGrid.java
+++ b/test/src/org/labkey/test/pages/cds/DataGrid.java
@@ -567,7 +567,10 @@ public class DataGrid
 
     public File exportGrid(boolean isExcel)
     {
-        return _test.clickAndWaitForDownload(Locator.css("a." + (isExcel ? "gridexportexcelbtn" : "gridexportcsvbtn")));
+        _test.waitForElement(Locator.css(("a.export-data"))).click();
+        WebElement menuItem = _test.waitForElement(Locator.css("div[id=" + (isExcel ? "excel-menu-item]" : "csv-menu-item]")));
+
+        return _test.clickAndWaitForDownload(menuItem);
     }
 
     private void verifyExportedCSVContent(File export, List<String> expectedContent)

--- a/test/src/org/labkey/test/pages/cds/DataGrid.java
+++ b/test/src/org/labkey/test/pages/cds/DataGrid.java
@@ -568,7 +568,8 @@ public class DataGrid
     public File exportGrid(boolean isExcel)
     {
         _test.waitForElement(Locator.css(("a.export-data"))).click();
-        WebElement menuItem = _test.waitForElement(Locator.css("div[id=" + (isExcel ? "excel-menu-item]" : "csv-menu-item]")));
+        Locator item = Locator.css("span.x-menu-item-text").withText(isExcel ? "Excel (*.XLS)" : "Comma separated values (*.CSV)");
+        WebElement menuItem = _test.waitForElement(item);
 
         return _test.clickAndWaitForDownload(menuItem);
     }

--- a/theme/connector/lib/ext-02.css
+++ b/theme/connector/lib/ext-02.css
@@ -6228,7 +6228,6 @@ x-boundlist-item {
     from(#fb4770),
     to(#fb2e5c)
   );
-  border-radius: 9px;
 }
 
 .x-menu-item-active .x-menu-item-text {

--- a/theme/connector/view/_Learn.scss
+++ b/theme/connector/view/_Learn.scss
@@ -941,3 +941,32 @@ img.detail-has-data-very-small {
     text-transform: uppercase;
   }
 }
+
+/* Export button styles (for learn and data grids) */
+.x-btn-rounded-inverted-accent-small .x-btn-arrow-light {
+  background-image: url(data:image/gif;base64,R0lGODlhCgAKAHAAACH5BAEAAAIALAAAAAAKAAoAgQAAAP///wAAAAAAAAIMlI+pyxr/XFyh2ZsKADs=);
+  background-repeat: no-repeat;
+  background-position-x: 100%;
+}
+
+.export-item {
+  background-color: $white;
+
+  .x-menu-item-text {
+    margin-left: 10px;
+  }
+  .export-item-icon {
+    background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIzLjAuNiwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA5IDEwIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA5IDEwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6IzAwMDAwMDt9Cjwvc3R5bGU+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik05LDd2MnYxSDhIMUgwVjdoMXYyaDdWN0g5eiBNNy4zMywzLjk0TDYuNjIsMy4yM0w1LDQuODVWMEg0djQuODVMMi4zOCwzLjIzTDEuNjcsMy45NEw0LjUsNi43N0w3LjMzLDMuOTR6Ii8+Cjwvc3ZnPgo=);
+    background-repeat: no-repeat;
+    background-position-x: 0%;
+    background-size: 12px;
+  }
+}
+
+/* Inverted download background when the menu item is active */
+.export-item.x-menu-item-active .export-item-icon {
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIzLjAuNiwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA5IDEwIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA5IDEwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6I0ZGRkZGRjt9Cjwvc3R5bGU+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik05LDd2MnYxSDhIMUgwVjdoMXYyaDdWN0g5eiBNNy4zMywzLjk0TDYuNjIsMy4yM0w1LDQuODVWMEg0djQuODVMMi4zOCwzLjIzTDEuNjcsMy45NEw0LjUsNi43N0w3LjMzLDMuOTR6Ii8+Cjwvc3ZnPgo=);
+  background-repeat: no-repeat;
+  background-position-x: 0%;
+  background-size: 12px;
+}

--- a/theme/connector/view/_Learn.scss
+++ b/theme/connector/view/_Learn.scss
@@ -942,13 +942,14 @@ img.detail-has-data-very-small {
   }
 }
 
-/* Export button styles (for learn and data grids) */
+/* Data export button, with light arrow icon */
 .x-btn-rounded-inverted-accent-small .x-btn-arrow-light {
   background-image: url(data:image/gif;base64,R0lGODlhCgAKAHAAACH5BAEAAAIALAAAAAAKAAoAgQAAAP///wAAAAAAAAIMlI+pyxr/XFyh2ZsKADs=);
   background-repeat: no-repeat;
   background-position-x: 100%;
 }
 
+/* Data export menu item, with download icon */
 .export-item {
   background-color: $white;
 

--- a/theme/connector/view/_Learn.scss
+++ b/theme/connector/view/_Learn.scss
@@ -942,11 +942,16 @@ img.detail-has-data-very-small {
   }
 }
 
-/* Data export button, with light arrow icon */
-.x-btn-rounded-inverted-accent-small .x-btn-arrow-light {
-  background-image: url(data:image/gif;base64,R0lGODlhCgAKAHAAACH5BAEAAAIALAAAAAAKAAoAgQAAAP///wAAAAAAAAIMlI+pyxr/XFyh2ZsKADs=);
+/* Data export button, with arrow icon */
+.x-btn-arrow-light {
+  background-image: url(images/learn/down-arrow-light.svg);
   background-repeat: no-repeat;
   background-position-x: 100%;
+  background-size: 11px;
+}
+
+.x-btn-rounded-inverted-accent-small-menu-active .x-btn-arrow-light {
+  background-image: url(images/learn/up-arrow-light.svg);
 }
 
 /* Data export menu item, with download icon */
@@ -957,7 +962,7 @@ img.detail-has-data-very-small {
     margin-left: 10px;
   }
   .export-item-icon {
-    background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIzLjAuNiwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA5IDEwIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA5IDEwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6IzAwMDAwMDt9Cjwvc3R5bGU+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik05LDd2MnYxSDhIMUgwVjdoMXYyaDdWN0g5eiBNNy4zMywzLjk0TDYuNjIsMy4yM0w1LDQuODVWMEg0djQuODVMMi4zOCwzLjIzTDEuNjcsMy45NEw0LjUsNi43N0w3LjMzLDMuOTR6Ii8+Cjwvc3ZnPgo=);
+    background-image: url(images/learn/download-icon-dark.svg);
     background-repeat: no-repeat;
     background-position-x: 0%;
     background-size: 12px;
@@ -966,8 +971,5 @@ img.detail-has-data-very-small {
 
 /* Inverted download background when the menu item is active */
 .export-item.x-menu-item-active .export-item-icon {
-  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIzLjAuNiwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA5IDEwIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA5IDEwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6I0ZGRkZGRjt9Cjwvc3R5bGU+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik05LDd2MnYxSDhIMUgwVjdoMXYyaDdWN0g5eiBNNy4zMywzLjk0TDYuNjIsMy4yM0w1LDQuODVWMEg0djQuODVMMi4zOCwzLjIzTDEuNjcsMy45NEw0LjUsNi43N0w3LjMzLDMuOTR6Ii8+Cjwvc3ZnPgo=);
-  background-repeat: no-repeat;
-  background-position-x: 0%;
-  background-size: 12px;
+  background-image: url(images/learn/download-icon-light.svg);
 }

--- a/webapp/Connector/src/button/Export.js
+++ b/webapp/Connector/src/button/Export.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2022 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+Ext.define('Connector.button.ExportButton', {
+
+    extend: 'Ext.button.Button',
+
+    alias: 'widget.exportbutton',
+
+    text : 'Export',
+
+    arrowCls : 'arrow-light',
+
+    initComponent : function() {
+
+        this.menu = {
+            bubbleEvents : ['click'],
+            defaults : {
+                cls : 'export-item',
+                iconCls: 'export-item-icon',
+            },
+            items : [{
+                text: 'Comma separated values (*.CSV)',
+                itemId : 'csv-menu-item'
+            },{
+                text: 'Excel (*.XLS)',
+                itemId : 'excel-menu-item'
+            }]
+        };
+
+        this.on('click', this.handleClick, this);
+        this.callParent();
+    },
+
+    handleClick : function(cmp, item) {
+        if (item.itemId) {
+            switch (item.itemId) {
+                case 'csv-menu-item' :
+                    this.fireEvent('exportcsv', item);
+                    break;
+                case 'excel-menu-item' :
+                    this.fireEvent('exportexcel', item);
+                    break;
+            }
+        }
+    }
+});

--- a/webapp/Connector/src/button/Export.js
+++ b/webapp/Connector/src/button/Export.js
@@ -25,10 +25,10 @@ Ext.define('Connector.button.ExportButton', {
             },
             items : [{
                 text: 'Comma separated values (*.CSV)',
-                id : 'csv-menu-item'
+                itemId : 'csv-menu-item'
             },{
                 text: 'Excel (*.XLS)',
-                id : 'excel-menu-item'
+                itemId : 'excel-menu-item'
             }]
         };
 
@@ -37,8 +37,8 @@ Ext.define('Connector.button.ExportButton', {
     },
 
     handleClick : function(cmp, item) {
-        if (item.id) {
-            switch (item.id) {
+        if (item.itemId) {
+            switch (item.itemId) {
                 case 'csv-menu-item' :
                     this.fireEvent('exportcsv', item);
                     break;

--- a/webapp/Connector/src/button/Export.js
+++ b/webapp/Connector/src/button/Export.js
@@ -13,6 +13,8 @@ Ext.define('Connector.button.ExportButton', {
 
     arrowCls : 'arrow-light',
 
+    cls : 'export-data',
+
     initComponent : function() {
 
         this.menu = {
@@ -23,10 +25,10 @@ Ext.define('Connector.button.ExportButton', {
             },
             items : [{
                 text: 'Comma separated values (*.CSV)',
-                itemId : 'csv-menu-item'
+                id : 'csv-menu-item'
             },{
                 text: 'Excel (*.XLS)',
-                itemId : 'excel-menu-item'
+                id : 'excel-menu-item'
             }]
         };
 
@@ -35,8 +37,8 @@ Ext.define('Connector.button.ExportButton', {
     },
 
     handleClick : function(cmp, item) {
-        if (item.itemId) {
-            switch (item.itemId) {
+        if (item.id) {
+            switch (item.id) {
                 case 'csv-menu-item' :
                     this.fireEvent('exportcsv', item);
                     break;

--- a/webapp/Connector/src/view/Grid.js
+++ b/webapp/Connector/src/view/Grid.js
@@ -82,14 +82,10 @@ Ext.define('Connector.view.Grid', {
                     xtype: 'actiontitle',
                     flex: 1,
                     text: 'View data grid',
-                    buttons: [
-                        this.getExportCSVButton(),
-                        this.getExportExcelButton()
-                    ]
                 }]
             }, {
                 xtype: 'container',
-                items: [this.getSourceTabHeader(), this.getSelectColumnsButton()],
+                items: [this.getSourceTabHeader(), this.getSelectColumnsButton(), this.getExportButton()],
                 layout: {
                     type: 'hbox'
                 }
@@ -188,36 +184,6 @@ Ext.define('Connector.view.Grid', {
         }
     },
 
-    getExportCSVButton : function() {
-        if (!this.exportCSVButton) {
-            this.exportCSVButton = Ext.create('Ext.button.Button', {
-                cls: 'gridexportcsvbtn',
-                ui: 'rounded-inverted-accent-text',
-                text: 'Export CSV',
-                margin: '0 15 0 0',
-                handler: this.requestExportCSV,
-                scope: this
-            });
-        }
-
-        return this.exportCSVButton;
-    },
-
-    getExportExcelButton : function() {
-        if (!this.exportExcelButton) {
-            this.exportExcelButton = Ext.create('Ext.button.Button', {
-                cls: 'gridexportexcelbtn',
-                ui: 'rounded-inverted-accent-text',
-                text: 'Export Excel',
-                margin: '0 15 0 0',
-                handler: this.requestExportExcel,
-                scope: this
-            });
-        }
-
-        return this.exportExcelButton;
-    },
-
     getSelectColumnsButton : function() {
         if (!this.selectColumnsButton) {
             this.selectColumnsButton = Ext.create('Ext.button.Button', {
@@ -230,6 +196,22 @@ Ext.define('Connector.view.Grid', {
         }
 
         return this.selectColumnsButton;
+    },
+
+    getExportButton : function() {
+        if (!this.exportButton) {
+            this.exportButton = {
+                xtype: 'exportbutton',
+                margin : '24 10 0 0',
+                width : 100,
+                listeners: {
+                    exportcsv : this.requestExportCSV,
+                    exportexcel : this.requestExportExcel,
+                    scope: this
+                }
+            }
+        }
+        return this.exportButton;
     },
 
     setVisibleWindow : function(win) {

--- a/webapp/Connector/src/view/MabGrid.js
+++ b/webapp/Connector/src/view/MabGrid.js
@@ -96,6 +96,9 @@ Ext.define('Connector.view.MabGrid', {
 
     getGridHeader : function() {
         if (!this.gridHeader) {
+            var buttons = this.getReportButtons();
+            buttons.push(this.getExportButton());
+
             this.gridHeader = Ext.create('Ext.container.Container', {
                 height: this.headerHeight,
                 ui: 'custom',
@@ -107,10 +110,7 @@ Ext.define('Connector.view.MabGrid', {
                     xtype: 'actiontitle',
                     flex: 1,
                     text: 'Explore monoclonal antibody (mAb) characterization data',
-                    buttons: [
-                        this.getExportCSVButton(),
-                        this.getExportExcelButton()
-                    ].concat(this.getReportButtons())
+                    buttons: buttons
                 }]
             });
         }
@@ -127,34 +127,20 @@ Ext.define('Connector.view.MabGrid', {
         }
     },
 
-    getExportCSVButton : function() {
-        if (!this.exportCSVButton) {
-            this.exportCSVButton = Ext.create('Ext.button.Button', {
-                cls: 'gridexportcsvbtn',
-                ui: 'rounded-inverted-accent-text',
-                text: 'Export CSV',
-                margin: '0 15 0 0',
-                handler: this.requestExportCSV,
-                scope: this
-            });
+    getExportButton : function() {
+        if (!this.exportButton) {
+            this.exportButton = {
+                xtype: 'exportbutton',
+                margin : '0 0 0 25',
+                width : 100,
+                listeners: {
+                    exportcsv : this.requestExportCSV,
+                    exportexcel : this.requestExportExcel,
+                    scope: this
+                }
+            }
         }
-
-        return this.exportCSVButton;
-    },
-
-    getExportExcelButton : function() {
-        if (!this.exportExcelButton) {
-            this.exportExcelButton = Ext.create('Ext.button.Button', {
-                cls: 'gridexportexcelbtn',
-                ui: 'rounded-inverted-accent-text',
-                text: 'Export Excel',
-                margin: '0 15 0 0',
-                handler: this.requestExportExcel,
-                scope: this
-            });
-        }
-
-        return this.exportExcelButton;
+        return this.exportButton;
     },
 
     getReportButtons : function() {

--- a/webapp/production/Connector/resources/images/learn/down-arrow-light.svg
+++ b/webapp/production/Connector/resources/images/learn/down-arrow-light.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+     y="0px"
+     viewBox="0 0 386.257 386.257" style="enable-background:new 0 0 386.257 386.257;" xml:space="preserve">
+<polygon fill="#FFFFFF" points="0,97 193,289 386,97"/>
+</svg>

--- a/webapp/production/Connector/resources/images/learn/download-icon-dark.svg
+++ b/webapp/production/Connector/resources/images/learn/download-icon-dark.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+     viewBox="0 0 9 10" style="enable-background:new 0 0 9 10;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#000000;}
+</style>
+    <path class="st0" d="M9,7v2v1H8H1H0V7h1v2h7V7H9z M7.33,3.94L6.62,3.23L5,4.85V0H4v4.85L2.38,3.23L1.67,3.94L4.5,6.77L7.33,3.94z"/>
+</svg>

--- a/webapp/production/Connector/resources/images/learn/download-icon-light.svg
+++ b/webapp/production/Connector/resources/images/learn/download-icon-light.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+     viewBox="0 0 9 10" style="enable-background:new 0 0 9 10;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+    <path class="st0" d="M9,7v2v1H8H1H0V7h1v2h7V7H9z M7.33,3.94L6.62,3.23L5,4.85V0H4v4.85L2.38,3.23L1.67,3.94L4.5,6.77L7.33,3.94z"/>
+</svg>

--- a/webapp/production/Connector/resources/images/learn/up-arrow-light.svg
+++ b/webapp/production/Connector/resources/images/learn/up-arrow-light.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+     y="0px"
+     viewBox="0 0 386.257 386.257" style="enable-background:new 0 0 386.257 386.257;" xml:space="preserve">
+<polygon fill="#FFFFFF" points="0,289 193,97 386,289"/>
+</svg>


### PR DESCRIPTION
#### Rationale
As part of this [feature request](https://docs.google.com/document/d/1QWDYnx_4BdCDxpMvLq3SWYW35DJqXAZExojGYg892aE/edit), we want to consolidate the export buttons for CSV and Excel formats into a single menu style button. We will be planning to use this button when data export support is added to the learn pages but for now this story is just to create the new component and wire it into the existing MAb and data grids.

![image](https://user-images.githubusercontent.com/5741543/170774100-54fa26a6-ec0a-4a49-a462-2574f723d1b3.png)

#### Changes
- add a new export button component
- styling to match specifications
- replace existing MAb and data grid buttons with the new button
- fix existing automated tests
