### PR TITLE
include the export widget in production mode

### DIFF
--- a/webapp/Connector/extapp.lib.xml
+++ b/webapp/Connector/extapp.lib.xml
@@ -44,6 +44,7 @@
         <!-- Application Widgets -->
         <script path="Connector/src/button/Image.js"/>
         <script path="Connector/src/button/RoundedButton.js"/>
+        <script path="Connector/src/button/Export.js"/>
         <script path="Connector/src/component/ActionTitle.js"/>
         <script path="Connector/src/component/AdvancedOption.js"/>
         <script path="Connector/src/component/AbstractAntigenSelection.js"/>


### PR DESCRIPTION
#### Rationale
In a previous [PR](https://github.com/LabKey/cds/pull/475), we introduced a new widget as part of the export button refactor. Unfortunately the widget didn't get included into the production builds.
