### PR TITLE
add task to compile blog entries to the report ETL

### DIFF
--- a/resources/etls/RunTemplates.xml
+++ b/resources/etls/RunTemplates.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <etl xmlns="http://labkey.org/etl/xml">
-    <name>Run Reports : (create_static_site, create_neutralization_curves)</name>
+    <name>Run Reports : (create_static_site, create_neutralization_curves, create_blogs)</name>
     <description>Refresh public site pages and other reports</description>
     <transforms>
         <transform id="step1" type="TaskRefTransformStep">
@@ -16,6 +16,14 @@
                 <settings>
                     <setting name="reportId" value="db:create_neutralization_curves"/>
                     <setting name="greeter" value="STEP2"/>
+                </settings>
+            </taskref>
+        </transform>
+        <transform id="step3" type="TaskRefTransformStep">
+            <taskref ref="org.labkey.di.pipeline.RunReportTask">
+                <settings>
+                    <setting name="reportId" value="db:create_blogs"/>
+                    <setting name="greeter" value="STEP3"/>
                 </settings>
             </taskref>
         </transform>


### PR DESCRIPTION
#### Rationale
This adds a third task to the ETL which runs R reports in CDS to automation the population of data. The task will execute the report : create_blogs which the CDS team will add to the staging and production servers.

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45728)