### PR TITLE
FR 45774 : Update the study pages “Interactive report” section to allow for any URL

### DIFF
--- a/resources/etls/LoadApplication.xml
+++ b/resources/etls/LoadApplication.xml
@@ -231,9 +231,8 @@
             <source schemaName="cds" queryName="ds_studymab"/>
             <destination schemaName="cds" queryName="studymab" targetOption="truncate"/>
         </transform>
-        <transform id="PopulateStudyReport" type="org.labkey.di.pipeline.TransformTask">
-            <source schemaName="cds" queryName="import_studyReport"/>
-            <destination schemaName="cds" queryName="studyReport" targetOption="truncate"/>
+        <transform id="PopulateStudyReport" type="TaskrefTransformStep">
+            <taskref ref="org.labkey.cds.data.steps.PopulateStudyReportTask"/>
         </transform>
         <transform id="PopulateStudyCuratedGroup" type="org.labkey.di.pipeline.TransformTask">
             <source schemaName="cds" queryName="import_studyCuratedGroup"/>

--- a/resources/schemas/cds.xml
+++ b/resources/schemas/cds.xml
@@ -1350,13 +1350,18 @@
         <columns>
             <column columnName="prot"/>
             <column columnName="cds_report_id"/>
+            <column columnName="cds_report_link"/>
+            <column columnName="cds_report_label"/>
             <column columnName="container"/>
         </columns>
     </table>
     <table tableName="studyReport" tableDbType="TABLE">
         <columns>
+            <column columnName="rowId"/>
             <column columnName="prot"/>
             <column columnName="cds_report_id"/>
+            <column columnName="cds_report_link"/>
+            <column columnName="cds_report_label"/>
             <column columnName="container"/>
         </columns>
     </table>

--- a/resources/schemas/dbscripts/postgresql/cds-22.005-22.006.sql
+++ b/resources/schemas/dbscripts/postgresql/cds-22.005-22.006.sql
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+TRUNCATE TABLE cds.import_studyReport;
+DROP TABLE cds.import_studyReport;
+
+CREATE TABLE cds.import_studyReport
+(
+    rowId SERIAL,
+    prot VARCHAR(250) NOT NULL,
+    cds_report_id INTEGER,
+    cds_report_link TEXT,
+    cds_report_label TEXT,
+    container ENTITYID NOT NULL,
+
+    CONSTRAINT PK_CDS_IMPORT_STUDY_REPORT PRIMARY KEY (rowId),
+    CONSTRAINT UQ_CDS_IMPORT_STUDY_REPORT UNIQUE (prot, cds_report_id, container, cds_report_link, cds_report_label)
+);
+
+TRUNCATE TABLE cds.studyReport;
+DROP TABLE cds.studyReport;
+
+CREATE TABLE cds.studyReport
+(
+    rowId SERIAL,
+    prot VARCHAR(250) NOT NULL,
+    cds_report_id INTEGER,
+    cds_report_link TEXT,
+    cds_report_label TEXT,
+    container ENTITYID NOT NULL,
+
+    CONSTRAINT PK_CDS_STUDY_REPORT PRIMARY KEY (rowId),
+    CONSTRAINT UQ_CDS_STUDY_REPORT UNIQUE (prot, cds_report_id, container, cds_report_link, cds_report_label)
+);

--- a/resources/schemas/dbscripts/postgresql/cds-22.005-22.006.sql
+++ b/resources/schemas/dbscripts/postgresql/cds-22.005-22.006.sql
@@ -14,34 +14,26 @@
  * limitations under the License.
  */
 
-TRUNCATE TABLE cds.import_studyReport;
-DROP TABLE cds.import_studyReport;
+--  Update cds.import_studyReport table
+ALTER TABLE cds.import_studyReport ADD COLUMN cds_report_link TEXT;
+ALTER TABLE cds.import_studyReport ADD COLUMN cds_report_label TEXT;
 
-CREATE TABLE cds.import_studyReport
-(
-    rowId SERIAL,
-    prot VARCHAR(250) NOT NULL,
-    cds_report_id INTEGER,
-    cds_report_link TEXT,
-    cds_report_label TEXT,
-    container ENTITYID NOT NULL,
+ALTER TABLE cds.import_studyReport DROP CONSTRAINT PK_ImportStudyReport; -- Drop 'PRIMARY KEY(prot, cds_report_id, container)' since cds_report_id can now be null if cds_report_link is provided
+ALTER TABLE cds.import_studyReport ALTER COLUMN cds_report_id DROP NOT NULL;
 
-    CONSTRAINT PK_CDS_IMPORT_STUDY_REPORT PRIMARY KEY (rowId),
-    CONSTRAINT UQ_CDS_IMPORT_STUDY_REPORT UNIQUE (prot, cds_report_id, container, cds_report_link, cds_report_label)
-);
+ALTER TABLE cds.import_studyReport ADD COLUMN rowId SERIAL;
+ALTER TABLE cds.import_studyReport ADD CONSTRAINT PK_CDS_IMPORT_STUDY_REPORT PRIMARY KEY (rowId);
 
-TRUNCATE TABLE cds.studyReport;
-DROP TABLE cds.studyReport;
+ALTER TABLE cds.import_studyReport ADD CONSTRAINT UQ_CDS_IMPORT_STUDY_REPORT UNIQUE (prot, cds_report_id, container, cds_report_link, cds_report_label);
 
-CREATE TABLE cds.studyReport
-(
-    rowId SERIAL,
-    prot VARCHAR(250) NOT NULL,
-    cds_report_id INTEGER,
-    cds_report_link TEXT,
-    cds_report_label TEXT,
-    container ENTITYID NOT NULL,
+-- Update cds.studyReport table
+ALTER TABLE cds.studyReport ADD COLUMN cds_report_link TEXT;
+ALTER TABLE cds.studyReport ADD COLUMN cds_report_label TEXT;
 
-    CONSTRAINT PK_CDS_STUDY_REPORT PRIMARY KEY (rowId),
-    CONSTRAINT UQ_CDS_STUDY_REPORT UNIQUE (prot, cds_report_id, container, cds_report_link, cds_report_label)
-);
+ALTER TABLE cds.studyReport DROP CONSTRAINT PK_studyReport; -- Drop 'PRIMARY KEY (prot, cds_report_id, container)' since cds_report_id can now be null if cds_report_link is provided
+ALTER TABLE cds.studyReport ALTER COLUMN cds_report_id DROP NOT NULL;
+
+ALTER TABLE cds.studyReport ADD COLUMN rowId SERIAL;
+ALTER TABLE cds.studyReport ADD CONSTRAINT PK_CDS_STUDY_REPORT PRIMARY KEY (rowId);
+
+ALTER TABLE cds.studyReport ADD CONSTRAINT UQ_CDS_STUDY_REPORT UNIQUE (prot, cds_report_id, container, cds_report_link, cds_report_label);

--- a/resources/schemas/dbscripts/postgresql/cds-22.005-22.006.sql
+++ b/resources/schemas/dbscripts/postgresql/cds-22.005-22.006.sql
@@ -16,7 +16,7 @@
 
 --  Update cds.import_studyReport table
 ALTER TABLE cds.import_studyReport ADD COLUMN cds_report_link TEXT;
-ALTER TABLE cds.import_studyReport ADD COLUMN cds_report_label TEXT;
+ALTER TABLE cds.import_studyReport ADD COLUMN cds_report_label VARCHAR(250);
 
 ALTER TABLE cds.import_studyReport DROP CONSTRAINT PK_ImportStudyReport; -- Drop 'PRIMARY KEY(prot, cds_report_id, container)' since cds_report_id can now be null if cds_report_link is provided
 ALTER TABLE cds.import_studyReport ALTER COLUMN cds_report_id DROP NOT NULL;
@@ -28,7 +28,7 @@ ALTER TABLE cds.import_studyReport ADD CONSTRAINT UQ_CDS_IMPORT_STUDY_REPORT UNI
 
 -- Update cds.studyReport table
 ALTER TABLE cds.studyReport ADD COLUMN cds_report_link TEXT;
-ALTER TABLE cds.studyReport ADD COLUMN cds_report_label TEXT;
+ALTER TABLE cds.studyReport ADD COLUMN cds_report_label VARCHAR(250);
 
 ALTER TABLE cds.studyReport DROP CONSTRAINT PK_studyReport; -- Drop 'PRIMARY KEY (prot, cds_report_id, container)' since cds_report_id can now be null if cds_report_link is provided
 ALTER TABLE cds.studyReport ALTER COLUMN cds_report_id DROP NOT NULL;

--- a/src/org/labkey/cds/CDSModule.java
+++ b/src/org/labkey/cds/CDSModule.java
@@ -177,7 +177,7 @@ public class CDSModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 22.005;
+        return 22.006;
     }
 
     @Override

--- a/src/org/labkey/cds/data/steps/PopulateStudyReportTask.java
+++ b/src/org/labkey/cds/data/steps/PopulateStudyReportTask.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2015 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.cds.data.steps;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.pipeline.PipelineJobException;
+import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.DefaultSchema;
+import org.labkey.api.query.QuerySchema;
+import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.query.ValidationException;
+import org.labkey.api.util.DateUtil;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class PopulateStudyReportTask extends AbstractPopulateTask
+{
+    @Override
+    protected void populate(Logger logger) throws PipelineJobException
+    {
+        long start = System.currentTimeMillis();
+
+        BatchValidationException errors = new BatchValidationException();
+
+        QuerySchema cdsSchema = DefaultSchema.get(user, project).getSchema("cds");
+
+        if (cdsSchema == null)
+            throw new PipelineJobException("Unable to find cds schema for folder " + project.getPath());
+
+        TableInfo sourceTable = cdsSchema.getTable("import_studyReport");
+        TableInfo targetTable = cdsSchema.getTable("studyReport");
+
+        QueryUpdateService targetService = targetTable.getUpdateService();
+
+        if (targetService == null)
+            throw new PipelineJobException("Unable to find update service for cds.studyReport in folder " + project.getPath());
+
+        //
+        // Truncate cds.studyReport
+        //
+        try
+        {
+            targetService.truncateRows(user, project, null, null);
+        }
+        catch (Exception e)
+        {
+            logger.error(e.getMessage(), e);
+        }
+
+        if (errors.hasErrors())
+        {
+            for (ValidationException error : errors.getRowErrors())
+            {
+                logger.error(error.getMessage());
+            }
+            return;
+        }
+
+        //
+        // Identify illegal combination of values
+        //
+        TableSelector source_ts = new TableSelector(sourceTable);
+
+        for (Map<String, Object> stringObjectMap : source_ts.getMapArray())
+        {
+            Integer reportId = (Integer) stringObjectMap.get("cds_report_id");
+            String reportLink = (String) stringObjectMap.get("cds_report_link");
+            String reportLabel = (String) stringObjectMap.get("cds_report_label");
+
+            // providing both an id and URL is illegal - we won't know which to render
+            if (null != reportId && StringUtils.isNotBlank(reportLink))
+            {
+                String msg = "Illegal combination: Both Report Id '" + reportId + "' and Report Link '" + reportLink + "' are provided, either Report Id or Report Link is expected.";
+                throw new PipelineJobException(msg);
+            }
+
+            // URL without a label should be illegal
+            if (StringUtils.isNotBlank(reportLink) && StringUtils.isBlank(reportLabel))
+            {
+                String msg = "Illegal combination: Report Label cannot be blank if Report Link is provided. Please provide a Report Label for Report Link '" + reportLink + "'.";
+                throw new PipelineJobException(msg);
+            }
+        }
+
+        if (source_ts.getRowCount() > 0)
+        {
+            try
+            {
+                List<Map<String, Object>> insertedRows = targetService.insertRows(user, project, Arrays.asList(source_ts.getMapArray()), errors, null, null);
+                long finish = System.currentTimeMillis();
+                logger.info("Inserted " + insertedRows.size() + " rows in cds.studyReport in " + DateUtil.formatDuration(finish - start) + ".");
+            }
+            catch (Exception e)
+            {
+                logger.error(e.getMessage(), e);
+            }
+        }
+
+        if (errors.hasErrors())
+        {
+            for (ValidationException error : errors.getRowErrors())
+            {
+                logger.error(error.getMessage());
+            }
+            return;
+        }
+    }
+}

--- a/test/sampledata/dataspace/cdsimport/StudyReport.txt
+++ b/test/sampledata/dataspace/cdsimport/StudyReport.txt
@@ -1,3 +1,4 @@
-prot	cds_report_id
+prot	cds_report_id	cds_report_link	cds_report_label
 q2	110000
 z110	110001
+q2		https://pubmed.ncbi.nlm.nih.gov/	Report A

--- a/webapp/Connector/src/app/store/Study.js
+++ b/webapp/Connector/src/app/store/Study.js
@@ -486,16 +486,19 @@ Ext.define('Connector.app.store.Study', {
 
                         var reportObj = this.savedReportsData.filter(function(val) { return val.reportId === id;}, this);
 
-                        if (reportObj && reportObj.length > 0) {
+                        if ((reportObj && reportObj.length > 0) || (reportLink && reportLabel)){
                             var report  = {
                                 report_id: id,
                                 report_link: reportLink,
-                                label: reportLabel ? reportLabel : (reportObj && reportObj[0] ? reportObj[0].reportName : undefined),
+                                label: reportLabel ? reportLabel : (id && reportObj && reportObj[0] ? reportObj[0].reportName : undefined)
                             };
                             interactiveReports.push(report);
                         }
                     }
                 }
+                interactiveReports.sort(function (r1, r2) {
+                    return r1.label.toLowerCase().localeCompare(r2.label.toLowerCase())
+                });
                 study.interactive_reports = interactiveReports;
 
                 var curatedGroups = [];

--- a/webapp/Connector/src/app/store/Study.js
+++ b/webapp/Connector/src/app/store/Study.js
@@ -481,12 +481,16 @@ Ext.define('Connector.app.store.Study', {
                 for (var i=0; i < this.studyReportsData.length; i++) {
                     if (study.study_name === this.studyReportsData[i].prot) {
                         var id = this.studyReportsData[i].cds_report_id ? this.studyReportsData[i].cds_report_id.toString() : undefined;
+                        var reportLink = this.studyReportsData[i].cds_report_link ? this.studyReportsData[i].cds_report_link: undefined;
+                        var reportLabel = this.studyReportsData[i].cds_report_label ? this.studyReportsData[i].cds_report_label: undefined;
+
                         var reportObj = this.savedReportsData.filter(function(val) { return val.reportId === id;}, this);
 
                         if (reportObj && reportObj.length > 0) {
                             var report  = {
                                 report_id: id,
-                                label: reportObj && reportObj[0] ? reportObj[0].reportName : undefined,
+                                report_link: reportLink,
+                                label: reportLabel ? reportLabel : (reportObj && reportObj[0] ? reportObj[0].reportName : undefined),
                             };
                             interactiveReports.push(report);
                         }

--- a/webapp/Connector/src/app/view/module/InteractiveReports.js
+++ b/webapp/Connector/src/app/view/module/InteractiveReports.js
@@ -21,6 +21,8 @@ Ext.define('Connector.view.module.InteractiveReports', {
                                 '<div class="item-value">',
                                     '<tpl if="report_id && label">',
                                         '<a href="#learn/learn/Report/db%3A{report_id}">{label:htmlEncode}</a>',
+                                    '<tpl elseif="report_link && label">',
+                                        '<a href="{report_link}">{label:htmlEncode}</a>',
                                     '</tpl>',
                                 '</div>',
                             '</td></tr>',


### PR DESCRIPTION
#### Rationale
Support URLs for external reports in addition to the internal reports generated within CDS application on Learn about > Study pages.
[Spec](https://docs.google.com/document/d/1l5no8D1UizAdquDCx9d9cs--c3K1SjrTkRfRyj2E6EE/edit#)

#### Changes
* Schema updates to add new columns.
* Add a new transform task class to validate/identify illegal combination of values.
* Update 'Interactive Report' section for Learn about > Study pages to list external reports as well.
