### PR TITLE
46095: Custom login page not respecting returnUrl parameter

### DIFF
--- a/resources/views/customLogin_2.html
+++ b/resources/views/customLogin_2.html
@@ -1,0 +1,9 @@
+<script type="text/javascript">
+    let returnUrl = LABKEY.ActionURL.getParameter("returnUrl");
+
+    // for now only use the returnUrl if it contains a reference to a webdav resource
+    if (returnUrl.indexOf('webdav') === -1)
+        window.location.replace(LABKEY.ActionURL.buildURL('cds', 'app', '/CAVD/'));
+    else
+        window.location.replace(LABKEY.ActionURL.buildURL('cds', 'app', '/CAVD/', {returnUrl: returnUrl}));
+</script>


### PR DESCRIPTION
#### Rationale
When users receive a link to a blog entry or file from the production server and they are not logged in, after being redirected to the app login page, they just end up on the CDS home page. This is because the custom login page configured for that server does a straight redirect using an HTML meta tag to:

https://dataspace.cavd.org/cds/CAVD/app.view

And the original returnUrl value is not propagated to the redirect.

[Related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46095)

#### Changes
- create a new custom login page : `customLogin_2.html`
- the page uses `javascript` to handle the redirect to `CAVD/app.view`
- if there is a `returnUrl` and the `URL` contains a reference to `_webdav` then it gets added to the redirect. This should result in the user getting navigated to the `returnUrl` after logging in successfully