### PR TITLE
Generalize tooltip repositioning code

### DIFF
--- a/webapp/Connector/src/app/view/LearnSummary.js
+++ b/webapp/Connector/src/app/view/LearnSummary.js
@@ -140,6 +140,7 @@ Ext.define('Connector.app.view.LearnSummary', {
         // the maximum count of data items to show per grouping
         var maxItems = 10;
         this.itemCount = 0;
+        var titleLines = 0;
 
         var config = this.dataAvailabilityTooltipConfig();
         var labelField = config.labelField || 'data_label';
@@ -177,17 +178,20 @@ Ext.define('Connector.app.view.LearnSummary', {
 
         if (config.title === "Publications") {
             if (accessible.length > 0) {
+                titleLines++;
                 dataAvailableListHTML += '<p>' + "Publication Data Available" + '</p>';
             }
         }
         else {
             if (accessible.length > 0) {
+                titleLines++;
                 dataAvailableListHTML += '<p class="data-availability-tooltip-header">' + config.title + " with Data Accessible" + '</p>';
                 dataAvailableListHTML += this.addDataAvailabilityItems(accessible, labelField, maxItems);
             }
             if (nonAccessible.length > 0) {
                 if (accessible.length > 0)
                     dataAvailableListHTML += '<br>';
+                titleLines++;
                 dataAvailableListHTML += '<p class="data-availability-tooltip-header">' + config.title + " without Data Accessible" + '</p>';
                 dataAvailableListHTML += this.addDataAvailabilityItems(nonAccessible, labelField, maxItems);
             }
@@ -197,12 +201,14 @@ Ext.define('Connector.app.view.LearnSummary', {
             }
 
             if (ni_accessible.length > 0) {
+                titleLines++;
                 dataAvailableListHTML += '<p class="data-availability-tooltip-header">' + niTitle + " with Data Accessible" + '</p>';
                 dataAvailableListHTML += this.addDataAvailabilityItems(ni_accessible, niLabelField, maxItems);
             }
             if (ni_nonAccessible.length > 0) {
                 if (accessible.length > 0)
                     dataAvailableListHTML += '<br>';
+                titleLines++;
                 dataAvailableListHTML += '<p class="data-availability-tooltip-header">' + niTitle + " without Data Accessible" + '</p>';
                 dataAvailableListHTML += this.addDataAvailabilityItems(ni_nonAccessible, niLabelField, maxItems);
             }
@@ -212,22 +218,18 @@ Ext.define('Connector.app.view.LearnSummary', {
             }
 
             if (availablePubData.length > 0) {
+                titleLines++;
                 dataAvailableListHTML += '<p class="data-availability-tooltip-header">' + pubTitle + " with Data Accessible" + '</p>';
                 dataAvailableListHTML += this.addDataAvailabilityItems(availablePubData, pubLabelField, maxItems);
             }
         }
 
         var itemWrapped = Ext.get(item);
-        var verticalPosition = itemWrapped.getAnchorXY()[1];
-        var viewHeight = itemWrapped.parent("#app-main").getHeight();
         var calloutHeight = 2 //borders
                             + 30 //content padding
-                            + 19 //title line height
-                            + 8 //title bottom padding
-                            + (17 //line height for content <li> elements
-                                * this.itemCount);
-
-        var verticalOffset = verticalPosition + calloutHeight > viewHeight ? calloutHeight - itemWrapped.getHeight() : 0;
+                            + (30 * titleLines) //title line height and padding
+                            + (17 * this.itemCount); //line height for content <li> elements
+        var offsets = PlotTooltipUtils.computeTooltipOffsets(item, calloutHeight);
 
         var calloutMgr = hopscotch.getCalloutManager(),
                 _id = options.id + (options.itemsWithPubDataAvailable ? ("-pub-" + options.itemsWithPubDataAvailable.length) : ''),
@@ -235,13 +237,13 @@ Ext.define('Connector.app.view.LearnSummary', {
                     calloutMgr.createCallout(Ext.apply({
                         id: _id,
                         xOffset: itemWrapped.el.dom.className === "detail-gray-text" ? -35 : 20,
-                        yOffset: itemWrapped.el.dom.className === "detail-gray-text" ? -verticalOffset-20 : -verticalOffset,
-                        arrowOffset: verticalOffset,
+                        yOffset: offsets.yOffset,
+                        arrowOffset: offsets.arrowOffset,
                         showCloseButton: false,
                         target: item,
                         placement: 'right',
                         content: dataAvailableListHTML,
-                        width: 220
+                        width: 300
                     }, {}));
                 }, 200);
 

--- a/webapp/Connector/src/app/view/module/DataAvailabilityModule.js
+++ b/webapp/Connector/src/app/view/module/DataAvailabilityModule.js
@@ -491,10 +491,17 @@ Ext.define('Connector.view.module.DataAvailabilityModule', {
                     var el = Ext4.get(item.id);
                     // race condition if we've navigated away
                     if (el && el.isVisible()) {
+
+                        // compute the callout height based on approximately 35 chars per line (plus title and margin)
+                        var lines = (content.length / 35) + 2;
+                        var calloutHeight = 30 + (17 * lines);
+                        var offsets = PlotTooltipUtils.computeTooltipOffsets(item, calloutHeight);
+
                         calloutMgr.createCallout(Ext.apply({
                             id: _id,
                             xOffset: 10,
-                            yOffset: -20,
+                            yOffset: offsets.yOffset,
+                            arrowOffset: offsets.arrowOffset,
                             showCloseButton: false,
                             target: item,
                             placement: 'right',

--- a/webapp/Connector/src/utility/PlotTooltip.js
+++ b/webapp/Connector/src/utility/PlotTooltip.js
@@ -486,6 +486,37 @@ Ext.define('Connector.utility.PlotTooltip', {
             }, this);
         }
         return content;
-    }
+    },
 
+    /**
+     * Utility to compute vertical offsets for a tooltip. Based on the height of the tooltip, viewport height, and
+     * location on the screen it will return properties which can be used directly in the hopscotch callout manager
+     * to create a tooltip that is adjusted vertically to avoid truncation.
+     *
+     * @param extItem the Ext object representing the tooltip owner
+     * @param calloutHeight the height (in pixels) of the expected tooltip
+     * @return an object which has properties : yOffset and arrowOffset that can be used directly in hopscotch.getCalloutManager().createCallout()
+     */
+    computeTooltipOffsets : function(extItem, calloutHeight) {
+        // defaults
+        var verticalOffset = 20;
+        var arrowOffset = 0;
+        var itemWrapped = Ext.get(extItem);
+        var verticalPosition = itemWrapped.getAnchorXY()[1];
+
+        if (itemWrapped.parent("#app-main")) {
+            var viewHeight = itemWrapped.parent("#app-main").getHeight();
+
+            if ((calloutHeight - 20) > (viewHeight - verticalPosition)) {
+                // callout is too tall, need to adjust the offsets
+                verticalOffset = (calloutHeight - 20) - (viewHeight - verticalPosition) + 25;
+                arrowOffset = verticalOffset - 10;
+            }
+        }
+
+        return {
+            yOffset : -verticalOffset,
+            arrowOffset : arrowOffset
+        };
+    }
 });

--- a/webapp/Connector/src/view/InfoPane.js
+++ b/webapp/Connector/src/view/InfoPane.js
@@ -619,7 +619,8 @@ Ext.define('Connector.view.InfoPane', {
     showItemTooltip : function(cmp, rec) {
         if (rec && rec.data.description) {
             var highlighted = Ext.dom.Query.select('div.single-axis-explorer:contains(' + rec.data.name + ')');
-            var el = Ext.get(highlighted[0]);
+            var item = highlighted[0];
+            var el = Ext.get(item);
 
             if (el) {
                 var calloutMgr = hopscotch.getCalloutManager(),
@@ -627,23 +628,14 @@ Ext.define('Connector.view.InfoPane', {
                         displayTooltip = setTimeout(function() {
                             // compute the callout height based on approximately 35 chars per line (plus margin)
                             var lines = rec.data.description.length / 35;
-                            var calloutHeight = 30 + (17 * lines);
-
-                            // shift the y-offset of the callout if it is larger than the 50 pixel margin we
-                            // have at the bottom of the info pane
-                            if (calloutHeight > 50) {
-                                verticalOffset = calloutHeight - 35;
-                                arrowOffset = verticalOffset - 14;
-                            } else {
-                                verticalOffset = calloutHeight / 2;
-                                arrowOffset = 0;
-                            }
+                            var calloutHeight = 50 + (17 * lines);
+                            var offsets = PlotTooltipUtils.computeTooltipOffsets(item, calloutHeight);
 
                             calloutMgr.createCallout(Ext.apply({
                                 id: _id,
                                 xOffset: -30,
-                                yOffset: -verticalOffset,
-                                arrowOffset: arrowOffset,
+                                yOffset: offsets.yOffset,
+                                arrowOffset: offsets.arrowOffset,
                                 showCloseButton: false,
                                 target: highlighted[0],
                                 placement: 'left',


### PR DESCRIPTION
#### Rationale
On occasion, the tooltip for the integrated data section of the learn about details pages could get truncated when the element was positioned near the bottom of the page:

![image](https://user-images.githubusercontent.com/5741543/188998093-2e8d20a0-0620-41ad-a2b1-9461f430466b.png)

There were a few places where we tried to adjust the tooltips vertically so they wouldn't get truncated, notably the data availability indicators on the learn pages and the tips on the info pane filters. The learn page indicators were perhaps the most sophisticated because the took into account the height of the tooltip, the position on the page and the size of the viewport to determine if the tooltip would render past the end of the page. 

This PR standardizes on a variant of the learn page algorithm and makes it available through the `singleton` utility class `PlotTooltipUtils`. The tooltips for the following pages are now managed using the new algorithm:
- learn page data availability
- info pane filter
- learn details integrated data

[Related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44308)