### PR TITLE
Test class updates

### DIFF
--- a/test/src/org/labkey/test/tests/cds/CDSFiltersTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSFiltersTest.java
@@ -18,6 +18,7 @@ package org.labkey.test.tests.cds;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.util.cds.CDSAsserts;
 import org.labkey.test.util.cds.CDSHelper;
@@ -30,6 +31,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 @Category({})
+@BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class CDSFiltersTest extends CDSReadOnlyTest
 {
 

--- a/test/src/org/labkey/test/tests/cds/CDSGridTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSGridTest.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.pages.cds.CDSExport;
 import org.labkey.test.pages.cds.CDSPlot;
@@ -46,6 +47,7 @@ import static org.labkey.test.util.cds.CDSHelper.GRID_COL_SUBJECT_ID;
 import static org.labkey.test.util.cds.CDSHelper.GRID_TITLE_NAB;
 
 @Category({})
+@BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class CDSGridTest extends CDSReadOnlyTest
 {
 

--- a/test/src/org/labkey/test/tests/cds/CDSGroupTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSGroupTest.java
@@ -24,6 +24,7 @@ import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.di.RunTransformResponse;
 import org.labkey.remoteapi.query.InsertRowsCommand;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.pages.cds.CDSPlot;
@@ -55,6 +56,7 @@ import static org.labkey.test.util.cds.CDSHelper.QED_2;
 import static org.labkey.test.util.cds.CDSHelper.ZAP_110;
 
 @Category({})
+@BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class CDSGroupTest extends CDSGroupBaseTest
 {
 

--- a/test/src/org/labkey/test/tests/cds/CDSHelpCenterTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSHelpCenterTest.java
@@ -19,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.util.cds.CDSHelpCenterUtil;
 import org.labkey.test.util.cds.CDSHelper;
@@ -39,6 +40,7 @@ import static org.labkey.test.util.cds.CDSHelpCenterUtil.DataSpaceR_LINK;
 import static org.labkey.test.util.cds.CDSHelpCenterUtil.TOOLS_TITLE;
 
 @Category({})
+@BaseWebDriverTest.ClassTimeout(minutes = 4)
 public class CDSHelpCenterTest extends CDSReadOnlyTest
 {
     private final CDSHelpCenterUtil helpCenter = new CDSHelpCenterUtil(this);

--- a/test/src/org/labkey/test/tests/cds/CDSHiddenVarsTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSHiddenVarsTest.java
@@ -17,11 +17,13 @@ package org.labkey.test.tests.cds;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.pages.cds.XAxisVariableSelector;
 import org.labkey.test.pages.cds.YAxisVariableSelector;
 import org.labkey.test.util.cds.CDSHelper;
 
 @Category({})
+@BaseWebDriverTest.ClassTimeout(minutes = 1)
 public class CDSHiddenVarsTest extends CDSReadOnlyTest
 {
     private final CDSHelper cds = new CDSHelper(this);

--- a/test/src/org/labkey/test/tests/cds/CDSLearnAboutExportTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSLearnAboutExportTest.java
@@ -10,9 +10,9 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.Git;
 import org.labkey.test.pages.cds.LearnGrid;
 import org.labkey.test.util.cds.CDSHelper;
 
@@ -27,7 +27,8 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Category({Git.class})
+@Category({})
+@BaseWebDriverTest.ClassTimeout(minutes = 3)
 public class CDSLearnAboutExportTest extends CDSReadOnlyTest
 {
     public static final String XPATH_SEARCH_BOX = "//table[contains(@class, 'learn-search-input')]//tbody//tr//td//input";

--- a/test/src/org/labkey/test/tests/cds/CDSLoginTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSLoginTest.java
@@ -18,6 +18,7 @@ package org.labkey.test.tests.cds;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.pages.cds.CDSLoginPage;
@@ -30,6 +31,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 @Category({})
+@BaseWebDriverTest.ClassTimeout(minutes = 2)
 public class CDSLoginTest extends CDSReadOnlyTest
 {
     @Before

--- a/test/src/org/labkey/test/tests/cds/CDSMAbTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSMAbTest.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.pages.cds.AntigenFilterPanel;
@@ -55,6 +56,7 @@ import static org.labkey.test.pages.cds.MAbDataGrid.TIERS_COL;
 import static org.labkey.test.pages.cds.MAbDataGrid.VIRUSES_COL;
 
 @Category({})
+@BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class CDSMAbTest extends CDSGroupBaseTest
 {
     private final CDSHelper cds = new CDSHelper(this);

--- a/test/src/org/labkey/test/tests/cds/CDSMeasureStoreTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSMeasureStoreTest.java
@@ -18,6 +18,7 @@ package org.labkey.test.tests.cds;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.pages.cds.DemoMeasureStorePage;
 
@@ -29,6 +30,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 @Category({})
+@BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class CDSMeasureStoreTest extends CDSReadOnlyTest
 {
     public static final String[] ICS_ELISPOT_DIMENSIONS = {"study_ICS_summary_level", "cds_GridBase_SequenceNum", "study_ICS_pctpos",

--- a/test/src/org/labkey/test/tests/cds/CDSPlotTimeTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSPlotTimeTest.java
@@ -20,8 +20,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
-import org.labkey.test.categories.Git;
 import org.labkey.test.pages.cds.CDSPlot;
 import org.labkey.test.pages.cds.ColorAxisVariableSelector;
 import org.labkey.test.pages.cds.DataspaceVariableSelector;
@@ -43,7 +43,8 @@ import java.util.regex.Pattern;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Category({Git.class})
+@Category({})
+@BaseWebDriverTest.ClassTimeout(minutes = 15)
 public class CDSPlotTimeTest extends CDSReadOnlyTest
 {
     private final CDSHelper cds = new CDSHelper(this);

--- a/test/src/org/labkey/test/tests/cds/CDSRReportsTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSRReportsTest.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.pages.cds.LearnGrid;
 import org.labkey.test.util.RReportHelper;
@@ -34,6 +35,7 @@ import static org.junit.Assert.assertTrue;
 import static org.labkey.test.util.cds.CDSHelper.NAB_MAB_DILUTION_REPORT;
 
 @Category({})
+@BaseWebDriverTest.ClassTimeout(minutes = 4)
 public class CDSRReportsTest extends CDSReadOnlyTest
 {
 

--- a/test/src/org/labkey/test/tests/cds/CDSSecurityTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSSecurityTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.dumbster.EmailRecordTable;
@@ -48,6 +49,7 @@ import static org.junit.Assert.assertTrue;
 import static org.labkey.test.tests.cds.CDSTestLearnAbout.XPATH_TEXTBOX;
 
 @Category({})
+@BaseWebDriverTest.ClassTimeout(minutes = 9)
 public class CDSSecurityTest extends CDSReadOnlyTest
 {
     private final CDSHelper cds = new CDSHelper(this);

--- a/test/src/org/labkey/test/tests/cds/CDSSubjectCountTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSSubjectCountTest.java
@@ -18,7 +18,7 @@ package org.labkey.test.tests.cds;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.labkey.test.categories.Git;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.pages.cds.CDSPlot;
 import org.labkey.test.pages.cds.InfoPane;
 import org.labkey.test.pages.cds.XAxisVariableSelector;
@@ -35,7 +35,8 @@ import java.util.Map;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@Category({Git.class})
+@Category({})
+@BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class CDSSubjectCountTest extends CDSReadOnlyTest
 {
     private final CDSHelper cds = new CDSHelper(this);

--- a/test/src/org/labkey/test/tests/cds/CDSTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSTest.java
@@ -19,6 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.pages.cds.ColorAxisVariableSelector;
 import org.labkey.test.pages.cds.DataspaceVariableSelector;
@@ -36,6 +37,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Category({})
+@BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class CDSTest extends CDSReadOnlyTest
 {
 

--- a/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
+++ b/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
@@ -20,10 +20,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.WebDriverWrapper;
-import org.labkey.test.categories.Git;
 import org.labkey.test.pages.cds.LearnDetailsPage;
 import org.labkey.test.pages.cds.LearnGrid;
 import org.labkey.test.util.cds.CDSAsserts;
@@ -41,7 +41,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@Category({Git.class})
+@Category({})
+@BaseWebDriverTest.ClassTimeout(minutes =27)
 public class CDSTestLearnAbout extends CDSReadOnlyTest
 {
     // whether column locking is enabled for the learn grids

--- a/test/src/org/labkey/test/tests/cds/CDSVisualizationBrushingTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSVisualizationBrushingTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 import static org.labkey.test.util.cds.CDSHelper.CDS_WAIT;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 15)
+@BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class CDSVisualizationBrushingTest extends CDSReadOnlyTest
 {
     private final CDSHelper cds = new CDSHelper(this);

--- a/test/src/org/labkey/test/tests/cds/CDSVisualizationPlotTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSVisualizationPlotTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertTrue;
 import static org.labkey.test.util.cds.CDSHelper.CDS_WAIT;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 30)
+@BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class CDSVisualizationPlotTest extends CDSReadOnlyTest
 {
     protected static final String MOUSEOVER_FILL = "#41C49F";

--- a/test/src/org/labkey/test/tests/cds/CDSVisualizationTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSVisualizationTest.java
@@ -50,7 +50,7 @@ import static org.labkey.test.util.cds.CDSHelper.PLOT_TYPE_LINE;
 import static org.labkey.test.util.cds.CDSHelper.PLOT_TYPE_SCATTER;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 30)
+@BaseWebDriverTest.ClassTimeout(minutes = 15)
 public class CDSVisualizationTest extends CDSReadOnlyTest
 {
     private final CDSHelper cds = new CDSHelper(this);


### PR DESCRIPTION
#### Rationale
Updating the test with below updates to be more consistent 
1. @BaseWebDriverTest.ClassTimeout 
2. @Category({}) because teamcity configuration will take care of running them in correct category.
#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
