### PR TITLE
Disable header locking for learn about reports

### DIFF
--- a/webapp/Connector/src/app/view/Report.js
+++ b/webapp/Connector/src/app/view/Report.js
@@ -37,7 +37,7 @@ Ext.define('Connector.app.view.Report', {
             xtype: 'templatecolumn',
             minWidth: 500,
             flex: 5 / 7,
-            locked: true,
+            locked: false,
             resizable: false,
             dataIndex: 'name',
             filterConfigSet: [{


### PR DESCRIPTION
#### Rationale
This is a follow on PR to the original work done to disable column locking on all of the learn about pages. The initial PR missed the reports tab.