### PR TITLE
Adding additional ten mins to timeout to account for initial set up.

### DIFF
--- a/test/src/org/labkey/test/tests/cds/CDSFiltersTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSFiltersTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 8)
+@BaseWebDriverTest.ClassTimeout(minutes = 18)
 public class CDSFiltersTest extends CDSReadOnlyTest
 {
 

--- a/test/src/org/labkey/test/tests/cds/CDSGridTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSGridTest.java
@@ -47,7 +47,7 @@ import static org.labkey.test.util.cds.CDSHelper.GRID_COL_SUBJECT_ID;
 import static org.labkey.test.util.cds.CDSHelper.GRID_TITLE_NAB;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 10)
+@BaseWebDriverTest.ClassTimeout(minutes = 20)
 public class CDSGridTest extends CDSReadOnlyTest
 {
 

--- a/test/src/org/labkey/test/tests/cds/CDSGroupTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSGroupTest.java
@@ -56,7 +56,7 @@ import static org.labkey.test.util.cds.CDSHelper.QED_2;
 import static org.labkey.test.util.cds.CDSHelper.ZAP_110;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 12)
+@BaseWebDriverTest.ClassTimeout(minutes = 22)
 public class CDSGroupTest extends CDSGroupBaseTest
 {
 

--- a/test/src/org/labkey/test/tests/cds/CDSHelpCenterTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSHelpCenterTest.java
@@ -40,7 +40,7 @@ import static org.labkey.test.util.cds.CDSHelpCenterUtil.DataSpaceR_LINK;
 import static org.labkey.test.util.cds.CDSHelpCenterUtil.TOOLS_TITLE;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 4)
+@BaseWebDriverTest.ClassTimeout(minutes = 14)
 public class CDSHelpCenterTest extends CDSReadOnlyTest
 {
     private final CDSHelpCenterUtil helpCenter = new CDSHelpCenterUtil(this);

--- a/test/src/org/labkey/test/tests/cds/CDSHiddenVarsTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSHiddenVarsTest.java
@@ -23,7 +23,7 @@ import org.labkey.test.pages.cds.YAxisVariableSelector;
 import org.labkey.test.util.cds.CDSHelper;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 1)
+@BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class CDSHiddenVarsTest extends CDSReadOnlyTest
 {
     private final CDSHelper cds = new CDSHelper(this);

--- a/test/src/org/labkey/test/tests/cds/CDSLearnAboutExportTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSLearnAboutExportTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 3)
+@BaseWebDriverTest.ClassTimeout(minutes = 13)
 public class CDSLearnAboutExportTest extends CDSReadOnlyTest
 {
     public static final String XPATH_SEARCH_BOX = "//table[contains(@class, 'learn-search-input')]//tbody//tr//td//input";

--- a/test/src/org/labkey/test/tests/cds/CDSLoginTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSLoginTest.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 2)
+@BaseWebDriverTest.ClassTimeout(minutes = 12)
 public class CDSLoginTest extends CDSReadOnlyTest
 {
     @Before

--- a/test/src/org/labkey/test/tests/cds/CDSMAbTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSMAbTest.java
@@ -56,7 +56,7 @@ import static org.labkey.test.pages.cds.MAbDataGrid.TIERS_COL;
 import static org.labkey.test.pages.cds.MAbDataGrid.VIRUSES_COL;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 10)
+@BaseWebDriverTest.ClassTimeout(minutes = 20)
 public class CDSMAbTest extends CDSGroupBaseTest
 {
     private final CDSHelper cds = new CDSHelper(this);

--- a/test/src/org/labkey/test/tests/cds/CDSMeasureStoreTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSMeasureStoreTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 10)
+@BaseWebDriverTest.ClassTimeout(minutes = 20)
 public class CDSMeasureStoreTest extends CDSReadOnlyTest
 {
     public static final String[] ICS_ELISPOT_DIMENSIONS = {"study_ICS_summary_level", "cds_GridBase_SequenceNum", "study_ICS_pctpos",

--- a/test/src/org/labkey/test/tests/cds/CDSPlotTimeTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSPlotTimeTest.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 15)
+@BaseWebDriverTest.ClassTimeout(minutes = 25)
 public class CDSPlotTimeTest extends CDSReadOnlyTest
 {
     private final CDSHelper cds = new CDSHelper(this);

--- a/test/src/org/labkey/test/tests/cds/CDSRReportsTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSRReportsTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 import static org.labkey.test.util.cds.CDSHelper.NAB_MAB_DILUTION_REPORT;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 4)
+@BaseWebDriverTest.ClassTimeout(minutes = 24)
 public class CDSRReportsTest extends CDSReadOnlyTest
 {
 

--- a/test/src/org/labkey/test/tests/cds/CDSReadOnlyTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSReadOnlyTest.java
@@ -29,7 +29,6 @@ import org.openqa.selenium.NoSuchElementException;
 import java.util.Arrays;
 import java.util.List;
 
-@BaseWebDriverTest.ClassTimeout(minutes = 45)
 public class CDSReadOnlyTest extends BaseWebDriverTest implements ReadOnlyTest, PostgresOnlyTest
 {
     @Override

--- a/test/src/org/labkey/test/tests/cds/CDSSecurityTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSSecurityTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertTrue;
 import static org.labkey.test.tests.cds.CDSTestLearnAbout.XPATH_TEXTBOX;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 12)
+@BaseWebDriverTest.ClassTimeout(minutes = 22)
 public class CDSSecurityTest extends CDSReadOnlyTest
 {
     private final CDSHelper cds = new CDSHelper(this);

--- a/test/src/org/labkey/test/tests/cds/CDSSubjectCountTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSSubjectCountTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 10)
+@BaseWebDriverTest.ClassTimeout(minutes = 20)
 public class CDSSubjectCountTest extends CDSReadOnlyTest
 {
     private final CDSHelper cds = new CDSHelper(this);

--- a/test/src/org/labkey/test/tests/cds/CDSTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSTest.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 7)
+@BaseWebDriverTest.ClassTimeout(minutes = 17)
 public class CDSTest extends CDSReadOnlyTest
 {
 

--- a/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
+++ b/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes =30)
+@BaseWebDriverTest.ClassTimeout(minutes = 40)
 public class CDSTestLearnAbout extends CDSReadOnlyTest
 {
     // whether column locking is enabled for the learn grids

--- a/test/src/org/labkey/test/tests/cds/CDSVisualizationBrushingTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSVisualizationBrushingTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 import static org.labkey.test.util.cds.CDSHelper.CDS_WAIT;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 10)
+@BaseWebDriverTest.ClassTimeout(minutes = 20)
 public class CDSVisualizationBrushingTest extends CDSReadOnlyTest
 {
     private final CDSHelper cds = new CDSHelper(this);

--- a/test/src/org/labkey/test/tests/cds/CDSVisualizationPlotTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSVisualizationPlotTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertTrue;
 import static org.labkey.test.util.cds.CDSHelper.CDS_WAIT;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 10)
+@BaseWebDriverTest.ClassTimeout(minutes = 20)
 public class CDSVisualizationPlotTest extends CDSReadOnlyTest
 {
     protected static final String MOUSEOVER_FILL = "#41C49F";

--- a/test/src/org/labkey/test/tests/cds/CDSVisualizationTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSVisualizationTest.java
@@ -50,7 +50,7 @@ import static org.labkey.test.util.cds.CDSHelper.PLOT_TYPE_LINE;
 import static org.labkey.test.util.cds.CDSHelper.PLOT_TYPE_SCATTER;
 
 @Category({})
-@BaseWebDriverTest.ClassTimeout(minutes = 15)
+@BaseWebDriverTest.ClassTimeout(minutes = 25)
 public class CDSVisualizationTest extends CDSReadOnlyTest
 {
     private final CDSHelper cds = new CDSHelper(this);


### PR DESCRIPTION
#### Rationale
On a new database the first test sets up all CDS project which roughly takes 10 mins, since we cannot control the order in which tests run increasing the timeouts by 10 mins is the solution.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
