### PR TITLE
Ticket 46665: Homepage url redirects to wrong page when logged in

### DIFF
--- a/resources/views/pageRedirect.html
+++ b/resources/views/pageRedirect.html
@@ -1,4 +1,4 @@
 <head>
     <p>Redirecting to Dataspace application...</p>
-    <meta http-equiv="refresh" content="0; URL=https://dataspace.cavd.org/cds/CAVD/app.view" />
+    <meta http-equiv="refresh" content="0; URL=/cds/CAVD/app.view" />
 </head>

--- a/resources/views/pageRedirect.html
+++ b/resources/views/pageRedirect.html
@@ -1,0 +1,4 @@
+<head>
+    <p>Redirecting to Dataspace application...</p>
+    <meta http-equiv="refresh" content="0; URL=https://dataspace.cavd.org/cds/CAVD/app.view" />
+</head>


### PR DESCRIPTION
#### Rationale
Ticket [46665](https://www.labkey.org/Dataspace/Support%20Tickets/issues-details.view?issueId=46665): Homepage url redirects to wrong page when logged in

https://dataspace.cavd.org/ takes users to https://dataspace.cavd.org/project/home/begin.view instead of the application page.

#### Changes
* Add html page for redirecting users to the main application page. This html page should be set in Look and Feel Settings --> Alternative site welcome page: cds/pageRedirect.view
