### PR TITLE
Update schema versions to 23.000

### DIFF
--- a/src/org/labkey/cds/CDSModule.java
+++ b/src/org/labkey/cds/CDSModule.java
@@ -177,7 +177,7 @@ public class CDSModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 22.006;
+        return 23.000;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
It's time to move the minimum schema version to 23.000