### PR TITLE
fix for learn details, interactive reports race condition

### DIFF
--- a/webapp/Connector/src/app/store/Assay.js
+++ b/webapp/Connector/src/app/store/Assay.js
@@ -85,7 +85,8 @@ Ext.define('Connector.app.store.Assay', {
                && Ext.isDefined(this.accessibleStudies)
                && Ext.isDefined(this.assayDocuments)
                && Ext.isDefined(this.assayReportsData)
-               && Ext.isDefined(this.savedReportsData)) {
+               && Ext.isDefined(this.savedReportsData)
+               && this.isLoadComplete()) {
 
             this.assayData.sort(function(assayA, assayB) {
                 return Connector.model.Filter.sorters.natural(assayA.assay_short_name, assayB.assay_short_name);

--- a/webapp/Connector/src/app/store/MAb.js
+++ b/webapp/Connector/src/app/store/MAb.js
@@ -56,7 +56,10 @@ Ext.define('Connector.app.store.MAb', {
     },
 
     _onLoadComplete : function() {
-        if (Ext.isDefined(this.mabMixData) && Ext.isDefined(this.mabMixStudies) && Ext.isDefined(this.accessibleStudies)) {
+        if (Ext.isDefined(this.mabMixData)
+                && Ext.isDefined(this.mabMixStudies)
+                && Ext.isDefined(this.accessibleStudies)
+                && this.isLoadComplete()) {
 
             this.mabMixData.sort(function(mab1, mab2) {
                 return Connector.model.Filter.sorters.natural(mab1.mab_mix_name_std, mab2.mab_mix_name_std);

--- a/webapp/Connector/src/app/store/Publication.js
+++ b/webapp/Connector/src/app/store/Publication.js
@@ -104,10 +104,14 @@ Ext.define('Connector.app.store.Publication', {
     },
 
     _onLoadComplete : function() {
-        if (Ext.isDefined(this.publicationData) && Ext.isDefined(this.studyData)
-                && Ext.isDefined(this.assayData) && Ext.isDefined(this.accessibleStudies)
+        if (Ext.isDefined(this.publicationData)
+                && Ext.isDefined(this.studyData)
+                && Ext.isDefined(this.assayData)
+                && Ext.isDefined(this.accessibleStudies)
                 && Ext.isDefined(this.publicationDocuments)
-                && Ext.isDefined(this.publicationReportsData) && Ext.isDefined(this.publicationCuratedGroupData)) {
+                && Ext.isDefined(this.publicationReportsData)
+                && Ext.isDefined(this.publicationCuratedGroupData)
+                && this.isLoadComplete()) {
 
             this.publicationData.sort(function(row1, row2) {
                 var date1Str = Connector.model.Filter.sorters.getPublicationDateSortStr(row1.date);

--- a/webapp/Connector/src/app/store/SavedReports.js
+++ b/webapp/Connector/src/app/store/SavedReports.js
@@ -38,7 +38,12 @@ Ext.define('Connector.app.store.SavedReports', {
         for (var x =0; x < rreports.length; x++) {
             this.savedReportsData.push({reportId: rreports[x].reportId.split(":")[1], reportName:rreports[x].name});
         }
+        this.loadComplete = true;
         this._onLoadComplete();
+    },
+
+    isLoadComplete : function() {
+        return this.loadComplete;
     },
 
     _onLoadComplete: function () {

--- a/webapp/Connector/src/app/store/Study.js
+++ b/webapp/Connector/src/app/store/Study.js
@@ -193,13 +193,21 @@ Ext.define('Connector.app.store.Study', {
         this._onLoadComplete();
     },
 
-    _onLoadComplete : function() {
-        if (Ext.isDefined(this.studyData) && Ext.isDefined(this.productData) && Ext.isDefined(this.assayData)
-                && Ext.isDefined(this.documentData) && Ext.isDefined(this.niDocumentData)
-                && Ext.isDefined(this.publicationData) && Ext.isDefined(this.relationshipData)
-                && Ext.isDefined(this.relationshipOrderData) && Ext.isDefined(this.accessibleStudies)
-                && Ext.isDefined(this.mabMixData) && Ext.isDefined(this.assayIdentifiers)
-                && Ext.isDefined(this.studyReportsData) && Ext.isDefined(this.studyCuratedGroupData)) {
+    _onLoadComplete: function () {
+        if (Ext.isDefined(this.studyData)
+                && Ext.isDefined(this.productData)
+                && Ext.isDefined(this.assayData)
+                && Ext.isDefined(this.documentData)
+                && Ext.isDefined(this.niDocumentData)
+                && Ext.isDefined(this.publicationData)
+                && Ext.isDefined(this.relationshipData)
+                && Ext.isDefined(this.relationshipOrderData)
+                && Ext.isDefined(this.accessibleStudies)
+                && Ext.isDefined(this.mabMixData)
+                && Ext.isDefined(this.assayIdentifiers)
+                && Ext.isDefined(this.studyReportsData)
+                && Ext.isDefined(this.studyCuratedGroupData)
+                && this.isLoadComplete()) {
             var studies = [], products, productNames, productClasses;
             var relationshipOrderList = this.relationshipOrderData.map(function(relOrder) {
                 return relOrder.relationship;

--- a/webapp/Connector/src/app/store/StudyProducts.js
+++ b/webapp/Connector/src/app/store/StudyProducts.js
@@ -148,8 +148,12 @@ Ext.define('Connector.app.store.StudyProducts', {
     },
 
     _onLoadComplete : function() {
-        if (Ext.isDefined(this.productData) && Ext.isDefined(this.studyData) && Ext.isDefined(this.productProduct)
-                && Ext.isDefined(this.accessibleStudies) && Ext.isDefined(this.studyAssayMap)) {
+        if (Ext.isDefined(this.productData)
+                && Ext.isDefined(this.studyData)
+                && Ext.isDefined(this.productProduct)
+                && Ext.isDefined(this.accessibleStudies)
+                && Ext.isDefined(this.studyAssayMap)
+                && this.isLoadComplete()) {
             var products = [],
                 studies,
                 studiesWithData,


### PR DESCRIPTION
#### Rationale
Recently, some changes to server side cacheing exposed a race condition in the learn pages. The symptom was that the interactive report section in learn details would contain either partial or no data. 

We need to introduce a way to hold off rendering the page until the `SavedReports` store had finished loading.

#### Changes
- Add the `SavedReports.isLoadComplete` and add that to the conditional logic in the overridden `_onLoadComplete` methods.
