### PR TITLE
Use non-deprecated JSON-related method and interface names

### DIFF
--- a/src/org/labkey/cds/CDSController.java
+++ b/src/org/labkey/cds/CDSController.java
@@ -1099,7 +1099,7 @@ public class CDSController extends SpringActionController
             }
             else if (isPost())
             {
-                JSONObject json = form.getNewJsonObject().optJSONObject("properties");
+                JSONObject json = form.getJsonObject().optJSONObject("properties");
 
                 if (null != json)
                 {


### PR DESCRIPTION
#### Rationale
`getNewJsonObject()` and `NewCustomApiForm` have replacements with better names