### PR TITLE
Ticket 47772: Improve performance when loading Learn about pages

### DIFF
--- a/webapp/Connector/src/view/Learn.js
+++ b/webapp/Connector/src/view/Learn.js
@@ -836,7 +836,9 @@ Ext.define('Connector.view.Learn', {
             this.getHeader().on('selectdimension', this.loadDataView, this, {single: true});
         }
 
-        // this.getHeader().selectTab(dimension ? dimension.uniqueName : undefined, id, dimension, params);
+        if (params && Object.keys(params).length > 0) {
+            this.getHeader().selectTab(dimension ? dimension.uniqueName : undefined, id, dimension, params);
+        }
     }
 
 });
@@ -1056,7 +1058,7 @@ Ext.define('Connector.view.LearnHeader', {
             this.getDataView().selectTab(dimUniqueName);
         }
         this.filterStoreFromUrlParams(id, dimension, params);
-        this.showExportButton(dimension);
+        // this.showExportButton(dimension);
     },
 
     filterStoreFromUrlParams: function(id, dimension, params)

--- a/webapp/Connector/src/view/Learn.js
+++ b/webapp/Connector/src/view/Learn.js
@@ -839,6 +839,10 @@ Ext.define('Connector.view.Learn', {
         if (params && Object.keys(params).length > 0) {
             this.getHeader().selectTab(dimension ? dimension.uniqueName : undefined, id, dimension, params);
         }
+
+        if (!Ext.isEmpty(this.getHeader().dimensions)) {
+            this.getHeader().getDataView().selectTab(dimension.uniqueName);
+        }
     }
 
 });
@@ -1054,9 +1058,9 @@ Ext.define('Connector.view.LearnHeader', {
     },
 
     selectTab : function(dimUniqueName, id, dimension, params) {
-        if (!Ext.isEmpty(this.dimensions)) {
-            this.getDataView().selectTab(dimUniqueName);
-        }
+        // if (!Ext.isEmpty(this.dimensions)) {
+        //     this.getDataView().selectTab(dimUniqueName);
+        // }
         this.filterStoreFromUrlParams(id, dimension, params);
         // this.showExportButton(dimension);
     },

--- a/webapp/Connector/src/view/Learn.js
+++ b/webapp/Connector/src/view/Learn.js
@@ -837,12 +837,15 @@ Ext.define('Connector.view.Learn', {
         }
 
         if (params && Object.keys(params).length > 0) {
-            this.getHeader().selectTab(dimension ? dimension.uniqueName : undefined, id, dimension, params);
+            this.getHeader().updateFilters(dimension, params, id != null);
         }
 
         if (!Ext.isEmpty(this.getHeader().dimensions)) {
             this.getHeader().getDataView().selectTab(dimension.uniqueName);
         }
+
+        this.getHeader().updateSearchValue(dimension, params);
+        this.getHeader().updateSort(dimension, params, id != null);
     }
 
 });
@@ -1058,11 +1061,11 @@ Ext.define('Connector.view.LearnHeader', {
     },
 
     selectTab : function(dimUniqueName, id, dimension, params) {
-        // if (!Ext.isEmpty(this.dimensions)) {
-        //     this.getDataView().selectTab(dimUniqueName);
-        // }
+        if (!Ext.isEmpty(this.dimensions)) {
+            this.getDataView().selectTab(dimUniqueName);
+        }
         this.filterStoreFromUrlParams(id, dimension, params);
-        // this.showExportButton(dimension);
+        this.showExportButton(dimension);
     },
 
     filterStoreFromUrlParams: function(id, dimension, params)

--- a/webapp/Connector/src/view/Learn.js
+++ b/webapp/Connector/src/view/Learn.js
@@ -830,12 +830,13 @@ Ext.define('Connector.view.Learn', {
 
         if (dimension) {
             this.loadDataView(dimension, id, urlTab, params);
+            this.getHeader().showExportButton(dimension);
         }
         else {
             this.getHeader().on('selectdimension', this.loadDataView, this, {single: true});
         }
 
-        this.getHeader().selectTab(dimension ? dimension.uniqueName : undefined, id, dimension, params);
+        // this.getHeader().selectTab(dimension ? dimension.uniqueName : undefined, id, dimension, params);
     }
 
 });

--- a/webapp/Connector/src/view/Learn.js
+++ b/webapp/Connector/src/view/Learn.js
@@ -830,22 +830,12 @@ Ext.define('Connector.view.Learn', {
 
         if (dimension) {
             this.loadDataView(dimension, id, urlTab, params);
-            this.getHeader().showExportButton(dimension);
         }
         else {
             this.getHeader().on('selectdimension', this.loadDataView, this, {single: true});
         }
 
-        if (params && Object.keys(params).length > 0) {
-            this.getHeader().updateFilters(dimension, params, id != null);
-        }
-
-        if (!Ext.isEmpty(this.getHeader().dimensions)) {
-            this.getHeader().getDataView().selectTab(dimension.uniqueName);
-        }
-
-        this.getHeader().updateSearchValue(dimension, params);
-        this.getHeader().updateSort(dimension, params, id != null);
+        this.getHeader().selectTab(dimension ? dimension.uniqueName : undefined, id, dimension, params, (!params || Object.keys(params).length === 0));
     }
 
 });
@@ -1060,19 +1050,22 @@ Ext.define('Connector.view.LearnHeader', {
         this.getDataView().setDimensions(dimensions);
     },
 
-    selectTab : function(dimUniqueName, id, dimension, params) {
+    selectTab : function(dimUniqueName, id, dimension, params, skipUpdateFilters) {
+
         if (!Ext.isEmpty(this.dimensions)) {
             this.getDataView().selectTab(dimUniqueName);
         }
-        this.filterStoreFromUrlParams(id, dimension, params);
+        this.filterStoreFromUrlParams(id, dimension, params, skipUpdateFilters);
         this.showExportButton(dimension);
     },
 
-    filterStoreFromUrlParams: function(id, dimension, params)
+    filterStoreFromUrlParams: function(id, dimension, params, skipUpdateFilters)
     {
         this.updateSearchValue(dimension, params);
         this.updateSort(dimension, params, id != null);
-        this.updateFilters(dimension, params, id != null);
+
+        if (!skipUpdateFilters)
+            this.updateFilters(dimension, params, id != null);
     },
 
     showExportButton: function(dimension) {


### PR DESCRIPTION
#### Rationale
Ticket [47772](https://www.labkey.org/Dataspace/Support%20Tickets/issues-details.view?issueId=47772): Improve performance when loading Learn about pages

This PR addresses part of the lag where the queries are being loaded twice.

#### Changes
* Call updateFilters() only when the params are not empty