### PR TITLE
Secure Issue 47890: Dataspace - Blank Assay page when navigating from Variables/Antigens Assay tabs to Learn grid

### DIFF
--- a/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
+++ b/test/src/org/labkey/test/tests/cds/CDSTestLearnAbout.java
@@ -807,13 +807,27 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
         List<String> assays = Arrays.asList(CDSHelper.ASSAYS_FULL_TITLES);
         _asserts.verifyLearnAboutPage(assays); // Until the data is stable don't count the assay's shown.
 
-        waitForElementToBeVisible(LEARN_ROW_TITLE_LOC.containing(assays.get(0)));
-        waitAndClick(LEARN_ROW_TITLE_LOC.containing(assays.get(0)));
+        LearnGrid learnGrid = new LearnGrid(this);
+        learnGrid.setSearch("BAMA");
+        learnGrid.clickFirstItem();
         sleep(CDSHelper.CDS_WAIT);
-        waitForElement(DETAIL_PAGE_BREADCRUMB_LOC.withText("Assays /"));
-        waitForElement(Locator.xpath("//h3[text()='Endpoint description']"));
+        waitForElementToBeVisible(Locator.tagWithText("h3", "Endpoint description"));
         assertTextPresent(CDSHelper.LEARN_ABOUT_BAMA_METHODOLOGY);
-        assertElementVisible(Locator.linkWithHref("#learn/learn/Assay/" + CDSHelper.ASSAYS[0].replace(" ", "%20") + "/antigens"));
+        assertElementPresent(Locator.linkWithText("View Antigen List"));
+        assertTrue("Incorrect link for antigen list",
+                Locator.linkWithText("View Antigen List").findElement(getDriver()).getAttribute("href").contains("#learn/learn/Assay/" + CDSHelper.ASSAYS[0].replace(" ", "%20") + "/antigens"));
+        /*
+            Test coverage for :
+            Secure Issue 47890: Dataspace - Blank Assay page when navigating from Variables/Antigens Assay tabs to Learn grid
+         */
+        click(Locator.linkWithText("View Antigen List")); // Navigates to antigen tab
+        waitForText("C.con.env03 140 CF");
+        click(Locator.tagWithClass("div", "iarrow"));
+        sleep(CDSHelper.CDS_WAIT);
+        _ext4Helper.waitForMaskToDisappear();
+        learnGrid = new LearnGrid(this);
+        learnGrid.clickFirstItem();
+        sleep(CDSHelper.CDS_WAIT);
 
         //testing variables page
         waitForElementToBeVisible(Locator.tagWithClass("h1", "lhdv").withText("Variables"));
@@ -859,7 +873,7 @@ public class CDSTestLearnAbout extends CDSReadOnlyTest
 
         // Go back to assays and validate the Data Added column.
         cds.viewLearnAboutPage("Assays");
-        LearnGrid learnGrid = new LearnGrid(this);
+        learnGrid = new LearnGrid(this);
         String toolTipText, cellText, expectedText;
         int dataAddedColumn = learnGrid.getColumnIndex("Data Added");
 

--- a/webapp/Connector/src/view/Learn.js
+++ b/webapp/Connector/src/view/Learn.js
@@ -613,8 +613,6 @@ Ext.define('Connector.view.Learn', {
                 // otherwise, show the listing
                 var listId = this.dataListPrefix + dimension.uniqueName;
 
-                console.log("*this.initialSelectedTab", this.initialSelectedTab);
-
                 // listView -- cache hit
                 // Secure Issue 47890: Dataspace - Blank Assay page after navigating to Assay subtabs such as Variables and Antigens
                 // Adding a check for this.initialSelectedTab will load from cache only when navigating from the Overview tab to Learn grid,

--- a/webapp/Connector/src/view/Learn.js
+++ b/webapp/Connector/src/view/Learn.js
@@ -615,7 +615,7 @@ Ext.define('Connector.view.Learn', {
 
                 // listView -- cache hit
                 // Secure Issue 47890: Dataspace - Blank Assay page after navigating to Assay subtabs such as Variables and Antigens
-                // Adding a check for this.initialSelectedTab will load from cache only when navigating from the Overview tab to Learn grid,
+                // Adding a check for this.initialSelectedTab will load from cache when navigating from the Overview tab to Learn grid,
                 // otherwise create the view when navigating from other tabs such as Assay's Variables or Antigens tabs.
                 if (this.initialSelectedTab === 0 && this.listViews[listId]) {
                     this.getComponent(listId).show();

--- a/webapp/Connector/src/view/Learn.js
+++ b/webapp/Connector/src/view/Learn.js
@@ -614,7 +614,7 @@ Ext.define('Connector.view.Learn', {
                 var listId = this.dataListPrefix + dimension.uniqueName;
 
                 // listView -- cache hit
-                // Secure Issue 47890: Dataspace - Blank Assay page after navigating to Assay subtabs such as Variables and Antigens
+                // Secure Issue 47890: Dataspace - Blank Assay page when navigating from Variables/Antigens Assay tabs to Learn grid
                 // Adding a check for this.initialSelectedTab will load from cache when navigating from the Overview tab to Learn grid,
                 // otherwise create the view when navigating from other tabs such as Assay's Variables or Antigens tabs.
                 if (this.initialSelectedTab === 0 && this.listViews[listId]) {

--- a/webapp/Connector/src/view/Learn.js
+++ b/webapp/Connector/src/view/Learn.js
@@ -30,6 +30,8 @@ Ext.define('Connector.view.Learn', {
 
     dimensionDataLoaded: {},
 
+    initialSelectedTab: 0,
+
     statics: {
         detailGridTabs : ['vars', 'antigens']
     },
@@ -611,8 +613,13 @@ Ext.define('Connector.view.Learn', {
                 // otherwise, show the listing
                 var listId = this.dataListPrefix + dimension.uniqueName;
 
+                console.log("*this.initialSelectedTab", this.initialSelectedTab);
+
                 // listView -- cache hit
-                if (this.listViews[listId]) {
+                // Secure Issue 47890: Dataspace - Blank Assay page after navigating to Assay subtabs such as Variables and Antigens
+                // Adding a check for this.initialSelectedTab will load from cache only when navigating from the Overview tab to Learn grid,
+                // otherwise create the view when navigating from other tabs such as Assay's Variables or Antigens tabs.
+                if (this.initialSelectedTab === 0 && this.listViews[listId]) {
                     this.getComponent(listId).show();
                 }
                 else {
@@ -754,6 +761,7 @@ Ext.define('Connector.view.Learn', {
         if (urlTab === 'antigens') {
             pageView.removeCls('auto-scroll-y');
         }
+        this.initialSelectedTab = pageView.initialSelectedTab;
         this.detailPageView = pageView;
         this.add(pageView);
     },


### PR DESCRIPTION
#### Rationale
Secure Issue [47890](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47890): Dataspace - Blank Assay page when navigating from Variables/Antigens Assay tabs to Learn grid

Navigating from Assay tabs such as Variables/Antigens back to Learn grid displays an empty Assay page; after this point, user have to refresh Learn > Assays page to see the data. This issue does not happen when navigating from the Overview tab.

#### Changes
* Create the view when navigating back to the Learn grid from Variables or Antigen tabs (instead of showing the view from the cache, which does not work as expected)
