### PR TITLE
Hide Learn Antigens tab if there is no data

### DIFF
--- a/webapp/Connector/src/view/Learn.js
+++ b/webapp/Connector/src/view/Learn.js
@@ -784,14 +784,10 @@ Ext.define('Connector.view.Learn', {
                 dimStore.on('load', function () {
                     me.dimensionDataLoaded[dimensionName] = true;
                     if (this.getCount() > 0) {
-                        me.dimensions = dimensions;
-                        me.getHeader().setDimensions(dimensions);
-                        filteredDimensions.push(dim)
+                        filteredDimensions.push(dim);
                     }
-                    else {
-                        me.dimensions = filteredDimensions;
-                        me.getHeader().setDimensions(filteredDimensions);
-                    }
+                    me.dimensions = filteredDimensions;
+                    me.getHeader().setDimensions(filteredDimensions);
                 });
                 dimStore.loadSlice();
             });


### PR DESCRIPTION
#### Rationale
Hide Learn Antigens tab if there is not data.

Initial fix was done in [this PR](https://github.com/LabKey/cds/pull/571). However, the fix was not thorough, it displayed the Antigens tab if the Reports had data to display.

#### Changes
* Add dimension to the display list Only if there is data for that particular dimension.
