### PR TITLE
Prevent stale element exception when viewing learn about pages

### DIFF
--- a/test/src/org/labkey/test/util/cds/CDSHelper.java
+++ b/test/src/org/labkey/test/util/cds/CDSHelper.java
@@ -1305,13 +1305,13 @@ public class CDSHelper
     {
         NavigationLink.LEARN.makeNavigationSelection(_test);
 
-        WebElement axisTab = _test.shortWait().until(ExpectedConditions.visibilityOfElementLocated(
-                Locator.tag("div").withClass("learn-dim-selector")
-                        .append(Locator.tag("h1").withClass("lhdv").withText(learnAxis))));
-
         Locator.XPathLocator rowLoc = Locator.xpath("//table[@role='presentation']//tr[@role='row']").withDescendant(Locator.byClass("detail-description")).notHidden();
         WebElement initialRow = rowLoc.waitForElement(_test.getDriver(), BaseWebDriverTest.WAIT_FOR_JAVASCRIPT);
         _test._ext4Helper.waitForMaskToDisappear();
+
+        WebElement axisTab = _test.shortWait().until(ExpectedConditions.visibilityOfElementLocated(
+                Locator.tag("div").withClass("learn-dim-selector")
+                        .append(Locator.tag("h1").withClass("lhdv").withText(learnAxis))));
 
         if (!axisTab.getAttribute("class").contains("active") &&
                 !Locator.tagWithAttribute("input", "placeholder", "Search " + learnAxis.toLowerCase()).existsIn(_test.getDriver()))


### PR DESCRIPTION
#### Rationale
Hitting numerous stale element exceptions on TeamCity after merging test changes from 23.3.
```
org.openqa.selenium.StaleElementReferenceException: The element reference of <h1 id="learn-header-Studies-id" class="lhdv"> is stale; either the element is no longer attached to the DOM, it is not in the current frame context, or the document has been refreshed
[...]
  at app//org.labkey.test.selenium.WebElementWrapper.getAttribute(WebElementWrapper.java:67)
  at app//org.labkey.test.util.cds.CDSHelper.viewLearnAboutPage(CDSHelper.java:1316)
  at app//org.labkey.test.tests.cds.CDSTestLearnAbout.verifySchemaLinks(CDSTestLearnAbout.java:189)
  at java.base@17.0.7/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

#### Related Pull Requests
* #587 

#### Changes
* Find grid headers after some grid rows have appeared
