### PR TITLE
Automation test for Add link to static blogs on public page

### DIFF
--- a/test/src/org/labkey/test/tests/cds/CDSStaticBlogsOnPublicPageTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSStaticBlogsOnPublicPageTest.java
@@ -1,0 +1,57 @@
+package org.labkey.test.tests.cds;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
+import org.labkey.test.TestFileUtils;
+import org.labkey.test.util.cds.CDSHelper;
+import org.labkey.test.util.core.webdav.WebDavUploadHelper;
+
+import java.io.File;
+import java.util.Arrays;
+
+@Category({})
+@BaseWebDriverTest.ClassTimeout(minutes = 5)
+public class CDSStaticBlogsOnPublicPageTest extends CDSReadOnlyTest
+{
+    private final CDSHelper cds = new CDSHelper(this);
+    protected static final File PUBLIC_FOLDER = TestFileUtils.getSampleData("/dataspace/publicPage");
+
+    @Test
+    public void testSteps()
+    {
+        goToHome();
+        goToModule("FileContent");
+        new WebDavUploadHelper(getCurrentContainerPath()).uploadDirectory(PUBLIC_FOLDER);
+
+        goToProjectHome();
+        cds.enterApplication();
+        cds.logOutFromApplication();
+
+        Locator moveDown = Locator.tagWithClass("a", "circle move-section-down");
+        waitForElement(moveDown);
+        cds.clickHelper(moveDown.findElement(getDriver()), () -> waitForText("10", "Assays"));
+        Assert.assertEquals("Always growing statistics is incorrect", "94\n" +
+                "Products\n" +
+                "55\n" +
+                "Studies\n" +
+                "8277\n" +
+                "Subjects\n" +
+                "10\n" +
+                "Assays", Locator.tagWithClass("div", "pill").findElement(getDriver()).getText());
+
+        cds.clickHelper(moveDown.index(1).findElement(getDriver()), () -> waitForText("Recent Blog Posts"));
+        Assert.assertTrue("News section is missing", isElementPresent(Locator.tagWithText("h1", "News")));
+        Assert.assertEquals("Incorrect number of thumbnails", 4,
+                Locator.tag("a").findElements(Locator.tagWithClass("tr", "thumbnail").findElement(getDriver())).size());
+        Assert.assertEquals("Incorrect blog publication dates", Arrays.asList("August 11, 2023", "July 25, 2023", "March 17, 2014", "January 28, 2014"),
+                getTexts(Locator.tag("td").findElements(Locator.tagWithClass("tr", "pub-date").findElement(getDriver()))));
+        Assert.assertEquals("Incorrect blog titles", Arrays.asList("Getting Started with Lab Inventory Tracking",
+                        "What's New in LabKey 23.7", "Release: LabKey Server v14.1", "Article: MedCity covers the LabKey story: \"Open-sourced in Seattle\""),
+                getTexts(Locator.tag("td").findElements(Locator.tagWithClass("tr", "blog-title").findElement(getDriver()))));
+        clickAndWait(Locator.linkWithId("thumbnail1"));
+        Assert.assertEquals("Incorrect navigation after thumbnail is clicked", "https://www.labkey.com/lab-inventory-tracking/", getURL().toString());
+    }
+}

--- a/test/src/org/labkey/test/util/cds/CDSInitializer.java
+++ b/test/src/org/labkey/test/util/cds/CDSInitializer.java
@@ -20,6 +20,7 @@ import org.labkey.remoteapi.core.SaveModulePropertiesCommand;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.params.ModuleProperty;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
@@ -206,13 +207,14 @@ public class CDSInitializer
         List<ModuleProperty> properties = List.of(
                 new ModuleProperty("CDS", "/", "GettingStartedVideoURL", "https://player.vimeo.com/video/142939542?color=ff9933&title=0&byline=0&portrait=0"),
                 new ModuleProperty("CDS", "/", "StaticPath", "/_webdav/CDSTest%20Project/@pipeline/cdsstatic/"),
+                new ModuleProperty("CDS", "/", "BlogPath", "/_webdav/home/%40files/publicPage/blogs/"),
+                new ModuleProperty("CDS", "/", "AllBlogsPath", WebTestHelper.getBaseURL() + "/_webdav/home/%40files/publicPage/blogs/all.html"),
                 new ModuleProperty("CDS", "/", "StudyDocumentPath", "/_webdav/DataSpaceStudyDocuments/@pipeline/cdsstatic/"),
                 new ModuleProperty("CDS", "/", "AssayDocumentPath", "/_webdav/DataSpaceStudyDocuments/@pipeline/cdsstatic/"),
                 new ModuleProperty("CDS", "/", "CDSImportPath", TestFileUtils.getSampleData("/dataspace/MasterDataspace/folder.xml").getParentFile().getParent())
         );
         SaveModulePropertiesCommand command = new SaveModulePropertiesCommand(properties);
         command.execute(_test.createDefaultConnection(), "/");
-
     }
 
     public void setHiddenVariablesProperty(boolean showHiddenVars) throws IOException, CommandException

--- a/webapp/Connector/test/testFeed.json
+++ b/webapp/Connector/test/testFeed.json
@@ -4,28 +4,28 @@
       "title": "Getting Started with Lab Inventory Tracking",
       "link": "https://www.labkey.com/lab-inventory-tracking/",
       "description": "Lab inventory tracking is an essential function for boosting efficiency and minimizing waste in scientific laboratories.",
-      "pubDate": "Fri, 11 Aug 2023 16:57:19 +0000",
+      "pubDate": "Fri, 11 Aug 2023",
       "thumbnail": "BlogAug112023.jpg"
     },
     {
       "title": "What's New in LabKey 23.7",
       "link": "https://www.labkey.com/whats-new-in-labkey-23-7/",
       "description": "New features in LabKey Server, Sample Manager and Biologics LIMS",
-      "pubDate": "Tue, 25 Jul 2023 21:05:51 +0000",
+      "pubDate": "Tue, 25 Jul 2023",
       "thumbnail": "WhatsNew23_7.jpg"
     },
     {
       "title": "Release: LabKey Server v14.1",
       "link": "http://www.labkey.com/news/news-releases/17032014-360",
       "description": "The LabKey team is delighted to announce the release of LabKey Server v14.1.",
-      "pubDate": "Mon, 17 Mar 2014 19:49:13 +0000",
+      "pubDate": "Mon, 17 Mar 2014",
       "thumbnail": "Stock.jpg"
     },
     {
       "title": "Article: MedCity covers the LabKey story: \"Open-sourced in Seattle\"",
       "link": "http://www.labkey.com/news/news-releases/28012014-356",
       "description": "Open-sourced in Seattle: A fated collision of software talent and life science researchers.",
-      "pubDate": "Tue, 28 Jan 2014 22:50:28 +0000",
+      "pubDate": "Tue, 28 Jan 2014",
       "thumbnail": "Stock.jpg"
     },
     {


### PR DESCRIPTION
#### Rationale
Automation test for [DataSpace] FR 45527: Add link to static blogs on public page

https://docs.google.com/document/d/1aYgnxAsJRPW8kTXnif8aQoU1gmaGsWdH2OeZ_qZIcQI/edit

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
