### PR TITLE
Use simpler, non-deprecated constructor

### DIFF
--- a/src/org/labkey/cds/CDSController.java
+++ b/src/org/labkey/cds/CDSController.java
@@ -200,7 +200,7 @@ public class CDSController extends SpringActionController
             // Limited user with Reader role otherwise no feeds will be returned by RSSService.get().getFeeds()
             if (!getContainer().hasPermission(user, ReadPermission.class))
             {
-                user = new LimitedUser(user, new int[0], Collections.singleton(RoleManager.getRole(ReaderRole.class)), false);
+                user = new LimitedUser(user, ReaderRole.class);
             }
             List<RSSFeed> feeds = RSSService.get().getFeeds(getContainer(), user);
 


### PR DESCRIPTION
#### Rationale
Old constructor is clunky and deprecated

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4733
