### PR TITLE
Enable the learn tabs to wrap to multiple lines

### DIFF
--- a/theme/connector/view/_Learn.scss
+++ b/theme/connector/view/_Learn.scss
@@ -101,6 +101,12 @@ div.learnview {
   }
 }
 
+.learnheader {
+  display: flex;
+  display: -webkit-flex;
+  flex-wrap: wrap;
+}
+
 .learn-data-available-module {
   .x-panel-body-default {
     border-width: 0;

--- a/webapp/Connector/src/app/view/LearnGrid.js
+++ b/webapp/Connector/src/app/view/LearnGrid.js
@@ -92,7 +92,6 @@ Ext.define('Connector.app.view.LearnGrid', {
         };
 
         this.listeners.learnGridResizeHeight = function (viewHeight) {
-            //console.log('learn grid resize height', this.learnView.headerViews.main.getHeight());
             this.setHeight(viewHeight - this.learnView.headerViews.main.getHeight());
             this.setTitleColumnWidth();
         };

--- a/webapp/Connector/src/app/view/LearnGrid.js
+++ b/webapp/Connector/src/app/view/LearnGrid.js
@@ -92,17 +92,18 @@ Ext.define('Connector.app.view.LearnGrid', {
         };
 
         this.listeners.learnGridResizeHeight = function (viewHeight) {
-            this.setHeight(viewHeight - this.learnView.headerViews.main.height);
+            //console.log('learn grid resize height', this.learnView.headerViews.main.getHeight());
+            this.setHeight(viewHeight - this.learnView.headerViews.main.getHeight());
             this.setTitleColumnWidth();
         };
 
         this.listeners.learnDetailsGridResizeHeight = function (viewHeight) {
-            this.setHeight(viewHeight - this.learnView.headerViews.main.height);
+            this.setHeight(viewHeight - this.learnView.headerViews.main.getHeight());
         };
 
         this.listeners.boxready = function (grid) {
             if (!this.isDetailLearnGrid) {
-                this.height = grid.container.getHeight() - this.learnView.headerViews.main.height;
+                this.height = grid.container.getHeight() - this.learnView.headerViews.main.getHeight();
                 this.setTitleColumnWidth();
             }
         };

--- a/webapp/Connector/src/view/Learn.js
+++ b/webapp/Connector/src/view/Learn.js
@@ -519,7 +519,8 @@ Ext.define('Connector.view.Learn', {
                     this.sortAndFilterStoreDelayed(store);
 
                     // after the grid store has loaded, fire the resize event to adjust final layout between the
-                    // header and grid
+                    // header and grid, this is necessary because the learn header is no longer a fixed height because
+                    // the styling has been adjusted to allow the learn tabs to wrap if there isn't enough horizontal space
                     var size = this.getSize();
                     this.fireEvent('resize', this, size.width, size.height);
                 }, this);
@@ -856,9 +857,6 @@ Ext.define('Connector.view.LearnHeader', {
 
     alias: 'widget.learnheader',
 
-    //height: 110,
-    //flex : 1,
-
     cls: 'header-container learnaboutheader',
 
     defaults: {
@@ -876,7 +874,6 @@ Ext.define('Connector.view.LearnHeader', {
         },{
             xtype: 'container',
             items: [this.getDataView(), this.getSearchField(), this.getExportButton()],
-            //height: 56,
             id: 'learn-header-bar-id',
             cls: 'learn-header-bar',
             layout: {
@@ -896,7 +893,6 @@ Ext.define('Connector.view.LearnHeader', {
         if (!this.headerDataView) {
             this.headerDataView = Ext.create('Connector.view.LearnHeaderDataView', {
                 flex: 2,
-                //minWidth: 725,
                 cls: 'learn-dim-selector',
                 dimensions: this.dimensions,
                 store: Ext.create('Ext.data.Store', {

--- a/webapp/Connector/src/view/Learn.js
+++ b/webapp/Connector/src/view/Learn.js
@@ -517,6 +517,11 @@ Ext.define('Connector.view.Learn', {
                 store.on('load', function() {
                     this.dimensionDataLoaded[dimensionName] = true;
                     this.sortAndFilterStoreDelayed(store);
+
+                    // after the grid store has loaded, fire the resize event to adjust final layout between the
+                    // header and grid
+                    var size = this.getSize();
+                    this.fireEvent('resize', this, size.width, size.height);
                 }, this);
                 if (hasHierarchy) {
                     Connector.getState().onMDXReady(function(mdx) {
@@ -851,7 +856,8 @@ Ext.define('Connector.view.LearnHeader', {
 
     alias: 'widget.learnheader',
 
-    height: 110,
+    //height: 110,
+    //flex : 1,
 
     cls: 'header-container learnaboutheader',
 
@@ -870,7 +876,7 @@ Ext.define('Connector.view.LearnHeader', {
         },{
             xtype: 'container',
             items: [this.getDataView(), this.getSearchField(), this.getExportButton()],
-            height: 56,
+            //height: 56,
             id: 'learn-header-bar-id',
             cls: 'learn-header-bar',
             layout: {
@@ -890,7 +896,7 @@ Ext.define('Connector.view.LearnHeader', {
         if (!this.headerDataView) {
             this.headerDataView = Ext.create('Connector.view.LearnHeaderDataView', {
                 flex: 2,
-                minWidth: 725,
+                //minWidth: 725,
                 cls: 'learn-dim-selector',
                 dimensions: this.dimensions,
                 store: Ext.create('Ext.data.Store', {


### PR DESCRIPTION
#### Rationale
We started noticing test failures related to the new `groups` tab that was added to the learn pages. While we couldn't consistently reproduce it locally the tests showed the `publications` tab wrapping to the second line but overlapping with the column headers on the learn grid.

This change forces the learn header to wrap the learn tabs when there isn't enough horizontal space to render all of the containing elements. Most of this was accomplished using `CSS` styling, but some adjustments had to be made to remove explicit heights for learn header elements so the layout manager could position container elements appropriately. 

If you are trying this PR out locally keep in mind you'll need to run `npm run build` to generate the theme stylesheets.

![image](https://github.com/LabKey/cds/assets/5741543/edaee63f-0260-45fa-9b6f-0f2942c1d5e7)
