### PR TITLE
Render n levels of treatment group nesting

### DIFF
--- a/webapp/Connector/src/app/store/StudyOverview.js
+++ b/webapp/Connector/src/app/store/StudyOverview.js
@@ -587,26 +587,32 @@ Ext.define('Connector.app.store.StudyOverview', {
     },
 
     parseGroupList : function(groupHtml){
+        /**
+         * Recursively search for child list items and attach them to
+         * the parent object
+         * @param parentNode the parent DOM node
+         * @param parent the parent object to record the hierarchy
+         */
+        const getChildren = function(parentNode, parent){
+            let nodeList = parentNode.querySelectorAll(':scope > ul > li');
+            if (nodeList) {
+                Ext.each(nodeList, function(node){
+                    // ignore empty list items <li></li>
+                    if (node.firstChild){
+                        var item = createItemObject(node);
+                        parent.children.push(item);
 
-        var getChildren = function(node, parent, indent){
-            // ignore empty list items <li></li>
-            if (node.firstChild){
-                var text = node.firstChild.data;
-
-                //console.log(indent + text);
-                var children = node.querySelectorAll(':scope > ul > li');
-                if (children && children.length > 0){
-                    return children;
-                }
-                else {
-                    return [];
-                }
+                        getChildren(node, item);
+                    }
+                });
             }
         };
 
-        // helper to create the representation of the items in the list, including child elements
-        var createItemObject = function(node){
-            // ignore empty list items
+        /**
+         * Helper to create the representation of the items in the list, including child elements
+         * @param node the DOM node
+         */
+        const createItemObject = function(node){
             if (node.firstChild){
                 return {name : node.firstChild.data, children : []};
             }
@@ -614,37 +620,12 @@ Ext.define('Connector.app.store.StudyOverview', {
         }
 
         // inject the raw HTML into a div, so we can query it
-        var groupDiv = document.createElement('div');
+        let groupDiv = document.createElement('div');
         groupDiv.innerHTML = groupHtml;
 
-        // get all the top level items
-        var groups = groupDiv.querySelectorAll(':scope > ul > li');
-        console.log('found ' + groups.length + ' top level items');
+        var parent = {name: 'top', children : []};
+        getChildren(groupDiv, parent);
 
-        // handle at most 2 levels of nesting, anything deeper will be ignored
-        var items = [];
-
-        Ext.each(groups, function(group){
-            var children = getChildren(group, null, '');
-
-            var item = createItemObject(group);
-            items.push(item);
-
-            Ext.each(children, function(child){
-                var child_1 = createItemObject(child);
-                item.children.push(child_1);
-
-                var children2 = getChildren(child, null, '\t');
-
-                Ext.each(children2, function(child){
-                    var child_2 = createItemObject(child);
-                    child_1.children.push(child_2);
-
-                    getChildren(child, null, '\t\t');
-                });
-            });
-        });
-
-        console.log(items);
+        console.log(parent);
     }
 });

--- a/webapp/Connector/src/app/store/StudyOverview.js
+++ b/webapp/Connector/src/app/store/StudyOverview.js
@@ -530,15 +530,7 @@ Ext.define('Connector.app.store.StudyOverview', {
                 var groups = groupDiv.querySelectorAll('div > ul > li');
                 var groupsArray = [];
 
-                console.log('found ' + groups.length + ' groups');
-                Ext.each(groups, function(group){
-                    var children = group.getElementsByTagName('li');
-                    if (children && children.length > 0){
-
-                        var item = group.firstChild.data;
-                        console.log(item + ' has ' + children.length + ' children');
-                    }
-                });
+                this.parseGroupList(study.groups);
 
                 if (groups && groups.length > 0) {
                     for (var k = 0; k < groups.length; k++) {
@@ -592,5 +584,44 @@ Ext.define('Connector.app.store.StudyOverview', {
             this.dataLoaded = true;
             this.fireEvent('dataloaded');
         }
+    },
+
+    parseGroupList : function(groupHtml){
+        // inject the raw HTML into a div, so we can query it
+        var groupDiv = document.createElement('div');
+        groupDiv.innerHTML = groupHtml;
+
+        // get all the top level items
+        var groups = groupDiv.querySelectorAll(':scope > ul > li');
+
+        var getChildren = function(group, indent){
+            // ignore empty list items <li></li>
+            if (group.firstChild){
+                var text = group.firstChild.data;
+                console.log(indent + text);
+                var children = group.querySelectorAll(':scope > ul > li');
+                if (children && children.length > 0){
+                    return children;
+                }
+                else {
+                    return [];
+                }
+            }
+        };
+
+        console.log('found ' + groups.length + ' top level items');
+
+        // handle at most 2 levels of nesting, anything deeper will be ignored
+        Ext.each(groups, function(group){
+            var children = getChildren(group, '');
+
+            Ext.each(children, function(child){
+                var children2 = getChildren(child, '\t');
+
+                Ext.each(children2, function(child){
+                    getChildren(child, '\t\t');
+                });
+            });
+        });
     }
 });

--- a/webapp/Connector/src/app/store/StudyOverview.js
+++ b/webapp/Connector/src/app/store/StudyOverview.js
@@ -525,23 +525,7 @@ Ext.define('Connector.app.store.StudyOverview', {
                 // process 'groups' to display 10 or more with show all/show less
                 var grpHeader= study.groups && study.groups.length > 0 ? study.groups.split('<ul>', 1) : undefined;
                 study.groups_header = grpHeader ? grpHeader[0] : undefined;
-                var groupDiv = document.createElement('div');
-                groupDiv.innerHTML = study.groups;
-                var groups = groupDiv.querySelectorAll('div > ul > li');
-                var groupsArray = [];
-
-                this.parseGroupList(study.groups);
-
-                if (groups && groups.length > 0) {
-                    for (var k = 0; k < groups.length; k++) {
-                        var str = groups[k].innerText;
-                        if (groupsArray.indexOf(str) === -1) {
-                            groupsArray.push({label: str});
-                        }
-                    }
-                }
-                study.groups_data = groupsArray;
-
+                study.groups_data = this.parseGroupList(study.groups);
                 var niAssaysAdded = study.non_integrated_assay_data.filter(function (value) {
                     return value.isLinkValid;
                 });
@@ -623,9 +607,8 @@ Ext.define('Connector.app.store.StudyOverview', {
         let groupDiv = document.createElement('div');
         groupDiv.innerHTML = groupHtml;
 
-        var parent = {name: 'top', children : []};
-        getChildren(groupDiv, parent);
-
-        console.log(parent);
+        var rootNode = {name: 'root', children : []};
+        getChildren(groupDiv, rootNode);
+        return rootNode.children;
     }
 });

--- a/webapp/Connector/src/app/store/StudyOverview.js
+++ b/webapp/Connector/src/app/store/StudyOverview.js
@@ -587,19 +587,14 @@ Ext.define('Connector.app.store.StudyOverview', {
     },
 
     parseGroupList : function(groupHtml){
-        // inject the raw HTML into a div, so we can query it
-        var groupDiv = document.createElement('div');
-        groupDiv.innerHTML = groupHtml;
 
-        // get all the top level items
-        var groups = groupDiv.querySelectorAll(':scope > ul > li');
-
-        var getChildren = function(group, indent){
+        var getChildren = function(node, parent, indent){
             // ignore empty list items <li></li>
-            if (group.firstChild){
-                var text = group.firstChild.data;
-                console.log(indent + text);
-                var children = group.querySelectorAll(':scope > ul > li');
+            if (node.firstChild){
+                var text = node.firstChild.data;
+
+                //console.log(indent + text);
+                var children = node.querySelectorAll(':scope > ul > li');
                 if (children && children.length > 0){
                     return children;
                 }
@@ -609,19 +604,47 @@ Ext.define('Connector.app.store.StudyOverview', {
             }
         };
 
+        // helper to create the representation of the items in the list, including child elements
+        var createItemObject = function(node){
+            // ignore empty list items
+            if (node.firstChild){
+                return {name : node.firstChild.data, children : []};
+            }
+            return null;
+        }
+
+        // inject the raw HTML into a div, so we can query it
+        var groupDiv = document.createElement('div');
+        groupDiv.innerHTML = groupHtml;
+
+        // get all the top level items
+        var groups = groupDiv.querySelectorAll(':scope > ul > li');
         console.log('found ' + groups.length + ' top level items');
 
         // handle at most 2 levels of nesting, anything deeper will be ignored
+        var items = [];
+
         Ext.each(groups, function(group){
-            var children = getChildren(group, '');
+            var children = getChildren(group, null, '');
+
+            var item = createItemObject(group);
+            items.push(item);
 
             Ext.each(children, function(child){
-                var children2 = getChildren(child, '\t');
+                var child_1 = createItemObject(child);
+                item.children.push(child_1);
+
+                var children2 = getChildren(child, null, '\t');
 
                 Ext.each(children2, function(child){
-                    getChildren(child, '\t\t');
+                    var child_2 = createItemObject(child);
+                    child_1.children.push(child_2);
+
+                    getChildren(child, null, '\t\t');
                 });
             });
         });
+
+        console.log(items);
     }
 });

--- a/webapp/Connector/src/app/store/StudyOverview.js
+++ b/webapp/Connector/src/app/store/StudyOverview.js
@@ -527,8 +527,18 @@ Ext.define('Connector.app.store.StudyOverview', {
                 study.groups_header = grpHeader ? grpHeader[0] : undefined;
                 var groupDiv = document.createElement('div');
                 groupDiv.innerHTML = study.groups;
-                var groups = groupDiv.querySelectorAll('ul li');
+                var groups = groupDiv.querySelectorAll('div > ul > li');
                 var groupsArray = [];
+
+                console.log('found ' + groups.length + ' groups');
+                Ext.each(groups, function(group){
+                    var children = group.getElementsByTagName('li');
+                    if (children && children.length > 0){
+
+                        var item = group.firstChild.data;
+                        console.log(item + ' has ' + children.length + ' children');
+                    }
+                });
 
                 if (groups && groups.length > 0) {
                     for (var k = 0; k < groups.length; k++) {

--- a/webapp/Connector/src/app/view/module/TreatmentSchemaGroup.js
+++ b/webapp/Connector/src/app/view/module/TreatmentSchemaGroup.js
@@ -27,8 +27,8 @@ Ext.define('Connector.view.module.TreatmentSchemaGroup', {
                         '<ul class="learn-study-info"><tbody>',
                             '<tpl for="groups_data">',
                                 '<tpl if="xindex &lt; 11">',
-                                    '<tpl if="label">',
-                                        '<li class="item-value" style="padding-right: 1em;">{label:htmlEncode}</li>',
+                                    '<tpl if="name">',
+                                        '{[this.renderNode(values)]}',
                                     '</tpl>',
                                 '</tpl>',
                             '</tpl>',
@@ -45,15 +45,41 @@ Ext.define('Connector.view.module.TreatmentSchemaGroup', {
                         '<ul class="learn-study-info">',
                             '<tpl for="groups_data">',
                                 '<tpl if="parent.showAll && (xindex &gt; 10)">',
-                                    '<tpl if="label">',
-                                        '<li class="item-value" style="padding-right: 1em;">{label:htmlEncode}</li>',
+                                    '<tpl if="name">',
+                                        '{[this.renderNode(values)]}',
                                     '</tpl>',
                                 '</tpl>',
                             '</tpl>',
                         '</ul>',
                 '</div>',
             '</tpl>',
-        '</tpl>'
+        '</tpl>',
+        {
+            nodeHtml : '',
+
+            // renders the top level group and child items recursively
+            renderNode : function(values){
+                this.nodeHtml = '';
+                this._renderItem(values);
+                return this.nodeHtml;
+            },
+
+            _renderItem(item){
+                this.nodeHtml = this.nodeHtml.concat(Ext.String.format('<li class="item-value" style="padding-right: 1em;">{0}', Ext.String.htmlEncode(item.name.trim())));
+                this._renderChildren(item.children);
+                this.nodeHtml = this.nodeHtml.concat('</li>');
+            },
+
+            _renderChildren(children){
+                if (children.length > 0){
+                    this.nodeHtml = this.nodeHtml.concat('<ul>');
+                    Ext.each(children, function(child){
+                        this._renderItem(child);
+                    }, this);
+                    this.nodeHtml = this.nodeHtml.concat('</ul>');
+                }
+            }
+        },
     ),
 
     initComponent : function() {


### PR DESCRIPTION
#### Rationale
[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49048)

The groups section in the study details learn pages are sourced by content from the `groups` field from the `cds.metadata.study` table. This content is in `HTML` format and is typically an unordered list of treatment groups and study ARMs. In order to limit the number of top level groups that are rendered on the page we parse the raw HTML to get the array of `li` items. The problem was that the previous code assumed only a single level of list items, but some of the protocols have nested sub-lists up to 2 levels deep: 

![image](https://github.com/LabKey/cds/assets/5741543/10d7acb5-e3b8-4553-af33-9852eef22add)

This PR introduces a change to support an arbitrary number of nesting levels (provided the HTML is reasonable well formed). And then renders those nesting levels in the details page while preserving the feature which limits the number of list items on the page (10). The limitation is applied only to the number of top level list items and does not count any of the sub nesting levels.



