### PR TITLE
Don't assume a container has any access for a given site group

### DIFF
--- a/test/src/org/labkey/test/tests/cds/CDSSecurityTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSSecurityTest.java
@@ -685,7 +685,11 @@ public class CDSSecurityTest extends CDSReadOnlyTest
         for (WebElement we : containerElements)
         {
             if (!we.getText().toLowerCase().equals(getProjectName().toLowerCase()))
-                containerAccess.put(we.getText(), Locator.xpath(PERMISSION_CELL_XPATH.replace("$", we.getText())).findElement(getDriver()).getText());
+            {
+                Locator role = Locator.xpath(PERMISSION_CELL_XPATH.replace("$", we.getText()));
+                if (isElementPresent(role))
+                    containerAccess.put(we.getText(), role.findElement(getDriver()).getText());
+            }
         }
 
         return containerAccess;


### PR DESCRIPTION
#### Rationale
`CDSSecurityTest.testSiteUserGroups` began to fail several weeks ago but because there were other failures that were masking the initial failure it was difficult to identify which commit the test began to fail on.

For example the FHCRC group has no access to the CDSTestProject, and the locator does not exist for that row thus causing the failure. 

![image](https://github.com/LabKey/cds/assets/5741543/b62335bb-3bcb-4582-aa8a-19d31bfa836e)



