### PR TITLE
Learn tabs initial selection state

### DIFF
--- a/webapp/Connector/src/view/Learn.js
+++ b/webapp/Connector/src/view/Learn.js
@@ -1058,6 +1058,14 @@ Ext.define('Connector.view.LearnHeader', {
 
     selectTab : function(dimUniqueName, id, dimension, params, skipUpdateFilters) {
 
+        // Issue 49121 : the store may not have been loaded yet (so the selection will fail), wait until
+        // dimensions have been loaded to set an initial selection
+        //
+        if (this.getDataView().getStore() && this.getDataView().getStore().getCount() == 0){
+            this.getDataView().getStore().on('load', function(){
+                this.getDataView().selectTab(dimUniqueName);
+            }, this);
+        }
         if (!Ext.isEmpty(this.dimensions)) {
             this.getDataView().selectTab(dimUniqueName);
         }


### PR DESCRIPTION
#### Rationale
[Tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49121)

There are a couple of scenarios where the learn tab selected state was not being rendered (magenta border):

- On initial app load when the user navigated from the home page to the learn pages. In this case the default tab is : study and while the tab was loaded, the selection state was blank.
- If the user refreshed to a URL with a learn tab specified : `cds-app.view#learn/learn/MAb`, again the tab was loaded correctly but the selection state was blank.

The issue that was causing this, is on learn view initialization the selected dimension happens before the learn header store gets loaded with dimensions, so the selection state fails to fire. My solution was to wait until the store loaded to make the initial selection. I briefly looked to see if the order of selection and store loading could easily be altered but that proved to be much more complex.

