### PR TITLE
Remove deprecated ContainerFilter.getSQLFragment

### DIFF
--- a/src/org/labkey/cds/query/MabGroupTable.java
+++ b/src/org/labkey/cds/query/MabGroupTable.java
@@ -85,7 +85,7 @@ public class MabGroupTable extends FilteredTable<CDSUserSchema>
         SQLFragment sql = new SQLFragment("(Shared = true OR CreatedBy = ");
         sql.append(getUserSchema().getUser().getUserId());
         sql.append(") AND ");
-        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("Container"), getContainer()));
+        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("Container")));
         addCondition(sql, containerFieldKey);
     }
 


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/platform/pull/5073 for rationale.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5073

#### Changes
* Remove `ContainerFilter.getSQLFragment(DbSchema, SQLFragment, Container)` and replace usages with calls to `ContainerFilter.getSQLFragment(DbSchema, SQLFragment)`.
