### PR TITLE
CDS : fix script nonce and inline event handlers

### DIFF
--- a/resources/cds-tours/wikis/tour-default-wiki
+++ b/resources/cds-tours/wikis/tour-default-wiki
@@ -12,10 +12,22 @@
 <!-- ${#labkey.dependency(path='_webdav/CDS/@files/tours/tour_view_data_grid.js')} -->
 
 <h3 class="tile-title tour-section-title">Take a Tour</h3>
-<!-- <div><a href="#" onclick="return hopscotch.startTour(tour_get_oriented);">Get oriented</a></div> -->
-<!-- <div><a href="#" onclick="return hopscotch.startTour(tour_active_filters);">Active filters</a></div> -->
-<!-- <div><a href="#" onclick="return hopscotch.startTour(tour_learn_about);">Learn about</a></div> -->
-<!-- <div><a href="#" onclick="return hopscotch.startTour(tour_find_subjects);">Find subjects</a></div> -->
-<!-- <div><a href="#" onclick="return hopscotch.startTour(tour_plot_data);">Plot data</a></div> -->
-<!-- <div><a href="#" onclick="return hopscotch.startTour(tour_view_data_grid);">View data grid</a></div> -->
-<!-- <div><a href="#" onclick="return hopscotch.startTour(tour_monoclonal_antibodies);">Monoclonal antibodies</a></div> -->
+<!-- <div><a href="#" class="tour_get_oriented">Get oriented</a></div> -->
+<!-- <div><a href="#" class="tour_active_filters">Active filters</a></div> -->
+<!-- <div><a href="#" class="tour_learn_about">Learn about</a></div> -->
+<!-- <div><a href="#" class="tour_find_subjects">Find subjects</a></div> -->
+<!-- <div><a href="#" class="tour_plot_data">Plot data</a></div> -->
+<!-- <div><a href="#" class="tour_view_data_grid">View data grid</a></div> -->
+<!-- <div><a href="#" class="tour_monoclonal_antibodies">Monoclonal antibodies</a></div> -->
+
+<script type="text/javascript">
+    LABKEY.Utils.onReady(function(){
+        $('a.tour_get_oriented').click(function(){hopscotch.startTour(tour_get_oriented);});
+        $('a.tour_active_filters').click(function(){hopscotch.startTour(tour_active_filters);});
+        $('a.tour_learn_about').click(function(){hopscotch.startTour(tour_learn_about);});
+        $('a.tour_find_subjects').click(function(){hopscotch.startTour(tour_find_subjects);});
+        $('a.tour_plot_data').click(function(){hopscotch.startTour(tour_plot_data);});
+        $('a.tour_view_data_grid').click(function(){hopscotch.startTour(tour_view_data_grid);});
+        $('a.tour_monoclonal_antibodies').click(function(){hopscotch.startTour(tour_monoclonal_antibodies);});
+    });
+</script>

--- a/resources/views/customLogin_2.html
+++ b/resources/views/customLogin_2.html
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script type="text/javascript" nonce="<%=scriptNonce%>">
     let returnUrl = LABKEY.ActionURL.getParameter("returnUrl");
 
     // for now only use the returnUrl if it contains a reference to a webdav resource

--- a/resources/views/olap_test.html
+++ b/resources/views/olap_test.html
@@ -1,9 +1,9 @@
 <div id='cube'></div>
 <div id='cellset'></div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<%=scriptNonce%>">
     LABKEY.requiresExt4Sandbox(true);
 </script>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<%=scriptNonce%>">
     LABKEY.requiresScript([
         'cds/olap.js',
         'cds/olap_test.js'

--- a/src/org/labkey/cds/view/template/ConnectorTemplate.jsp
+++ b/src/org/labkey/cds/view/template/ConnectorTemplate.jsp
@@ -55,7 +55,7 @@
 
     <!-- Include base labkey.js -->
     <%=PageFlowUtil.getLabkeyJS(getViewContext(), pageConfigBean, new LinkedHashSet<>(), false)%>
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="<%=getScriptNonce()%>">
         var Connector = {
             studyContext: {
                 schemaName: 'study',

--- a/src/org/labkey/cds/view/template/FrontPage.jsp
+++ b/src/org/labkey/cds/view/template/FrontPage.jsp
@@ -67,13 +67,13 @@
 
     <!-- Include base labkey.js -->
     <%=PageFlowUtil.getLabkeyJS(getViewContext(), null, null, false)%>
-    <script data-main="<%=getContextPath()%>/frontpage/js/config" src="<%=getWebappURL("/frontpage/components/requirejs/require.js")%>"></script>
+    <script data-main="<%=getContextPath()%>/frontpage/js/config" src="<%=getWebappURL("/frontpage/components/requirejs/require.js")%>" nonce="<%=getScriptNonce()%>"></script>
 
     <%--<!-- Client API Dependencies -->--%>
     <%=getScriptTag("/clientapi/labkey-api-js-core.min.js")%>
     <%=getScriptTag("/frontpage/components/jquery/dist/jquery.min.js")%>
     <%=getScriptTag("/passwordGauge.js")%>
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="<%=getScriptNonce()%>">
         reloadRegisterPage = function() {
             window.location = LABKEY.ActionURL.buildURL('cds', 'app', LABKEY.container.path, {register: "TRUE"});
         };
@@ -251,7 +251,7 @@
                 <div class="title">
                     <h1>Sign-in Help</h1>
                     <span class="help-info">The DataSpace is open to members with a registered account.<br>To set or reset your password, type in your email address and click the submit button.</span>
-                    <br><span class="help-info">Don't have an account? Click <a class="register-links" onclick="return reloadRegisterPage();">here</a> to register</span>
+                    <br><span class="help-info">Don't have an account? Click <a class="register-links" id="register-user-modal" href="#">here</a> to register</span>
                 </div>
                 <div class="notifications">
                     <p></p>
@@ -299,7 +299,7 @@
                         <span class="help-info" style="display: block;">
                             To help protect against abuse by bots, please enter the six characters shown below (case insensitive).
                         </span>
-                        <div class="kaptcha" onclick="return reloadRegisterPage();">
+                        <div class="kaptcha">
                             <img src="<%=getWebappURL("/kaptcha.jpg")%>" alt="Verification text" title="Click to get a new image." height="50" width="200"/>
                             <br><a class="register-links">Click to get a different image</a>
                         </div>
@@ -318,7 +318,7 @@
                 <div class="title">
                     <h1>Sign-in Help</h1>
                     <span class="help-info">The DataSpace is open to members with a registered account.<br>To set or reset your password, type in your email address and click the submit button.</span>
-                    <br><span class="help-info">Don't have an account? Click <a class="register-links" data-click="help-register">here</a> to register</span>
+                    <br><span class="help-info">Don't have an account? Click <a class="register-links" href="#" data-click="help-register">here</a> to register</span>
                 </div>
                 <div class="notifications">
                     <p></p>

--- a/webapp/Connector/src/app/view/module/AssayTutorial.js
+++ b/webapp/Connector/src/app/view/module/AssayTutorial.js
@@ -41,7 +41,7 @@ Ext.define('Connector.view.module.AssayTutorial', {
                             '<tr><td>',
                                 '<div class="assay-tutorial-img-container">',
                                     '<div>',
-                                        '<a id="assay-tutorial-video" onclick="Connector.view.module.AssayTutorial.openPopupModal(\'{assay_tutorial_link:htmlEncode}\');">',
+                                        '<a class="assay-tutorial-video" url="{assay_tutorial_link:htmlEncode}">',
                                             '<img style="max-width:99%;max-height:99%;height:auto" src={[this.getThumbnailImgSrc()]}/>',
                                         '</a>',
                                         '<div class="assay-tutorial-label">{video_thumbnail_label:htmlEncode}</div>',
@@ -91,11 +91,21 @@ Ext.define('Connector.view.module.AssayTutorial', {
                    data['valid_doc_link_count']++;
                 }
                 this.update(data);
+                // need to force a refresh so event listeners below can be re-attached
+                this.refresh();
             };
             this.on("afterrender", function() {
                 this.validateDocLinks(data.assayTutorialDocuments, docIsValidAction);
             }, this);
         }
+
+        this.on('refresh', function(){
+            LABKEY.Utils.attachEventHandlerForQuerySelector("a.assay-tutorial-video", "click", function (event) {
+                const target = event.currentTarget;
+                const url = target.getAttribute('url');
+                Connector.view.module.AssayTutorial.openPopupModal(url);
+            });
+        });
     },
 
     getListData : function () {

--- a/webapp/Connector/src/app/view/module/StudyResources.js
+++ b/webapp/Connector/src/app/view/module/StudyResources.js
@@ -14,7 +14,7 @@ Ext.define('Connector.view.module.StudyResources', {
             '<h3>{title_study_resources:htmlEncode}</h3>',
 
             '<div class="item-row">',
-                'Contact the <a href="mailto:dataspace.support@scharp.org?Subject=CAVD%20DataSpace%20request%20for%20information" onclick="Connector.controller.Analytics.onMailRequest();" target="_blank">DataSpace team</a> for more information<br/>',
+                'Contact the <a class="contact-dataspace-team" href="mailto:dataspace.support@scharp.org?Subject=CAVD%20DataSpace%20request%20for%20information" target="_blank">DataSpace team</a> for more information<br/>',
             '</div>',
             '<tpl if="network == \'CAVD\'">',
             '<div class="item-row">',
@@ -52,5 +52,11 @@ Ext.define('Connector.view.module.StudyResources', {
         var data = this.initialConfig.data.model.data;
         data['title_study_resources'] = this.initialConfig.data.title;
         this.update(data);
+
+        this.on('render', function(){
+            LABKEY.Utils.attachEventHandlerForQuerySelector("a.contact-dataspace-team", "click", function (event) {
+                Connector.controller.Analytics.onMailRequest();
+            });
+        });
     }
 });

--- a/webapp/Connector/src/component/Started.js
+++ b/webapp/Connector/src/component/Started.js
@@ -20,7 +20,7 @@ Ext.define('Connector.component.Started', {
             '</tpl>',
             '>',
             '<h1 class="started-section-title bottom-spacer">Getting Started</h1>',
-            '<a id="hidelink" href="#" onclick="return false;" class="started-dismiss">Hide &nbsp; <span style="font-size: 9px">&#x2715;</span></a>',
+            '<a id="hidelink" href="#" class="started-dismiss">Hide &nbsp; <span style="font-size: 9px">&#x2715;</span></a>',
             '<tpl if="videoURL">',
                 '<div style="height:auto" class="get-started ',
             '<tpl if="multiRow">',
@@ -69,7 +69,7 @@ Ext.define('Connector.component.Started', {
                     '<table class="tile">',
                         '<tr><td class="tile-image"><div class="home_integrated_data backgroundimage"></div></td></tr>',
                         '<tr><td style="padding-left:10%;white-space: normal"><div id="whatyouneedtoknow-wiki">{[this.getWhatYouNeedToKnowWiki()]}</div></td></tr>',
-                        '<tr><td style="padding-top: 5%;padding-left:10%;"><div id="helpCenter">See the <a id="helpCenterDialog" class="helpcenter-panel" href="#" onclick="return false">Help</a> section for more info</div></td></tr>',
+                        '<tr><td style="padding-top: 5%;padding-left:10%;"><div id="helpCenter">See the <a id="helpCenterDialog" class="helpcenter-panel" href="#">Help</a> section for more info</div></td></tr>',
                     '</table>',
                 '</div></td>',
 
@@ -103,7 +103,7 @@ Ext.define('Connector.component.Started', {
                 }
             },
             '</div></div>',
-            '<a id="showlink" href="#" onclick="return false;" class="started-show"',
+            '<a id="showlink" href="#" class="started-show"',
             '<tpl if="showIntro==true">',
             ' style="display: none;"',
             '</tpl>',

--- a/webapp/Connector/src/view/GroupSummary.js
+++ b/webapp/Connector/src/view/GroupSummary.js
@@ -332,7 +332,7 @@ Ext.define('Connector.view.GroupSummaryBody', {
             this._undo = Ext.create('Ext.Component', {
                 margin: '0 0 20 0',
                 renderTpl: new Ext.XTemplate(
-                    'Group loaded. Your ' + mabMsg + 'filters have been replaced. <a href="#" onclick="return false;" class="undogroup nav">Undo</a>'
+                    'Group loaded. Your ' + mabMsg + 'filters have been replaced. <a href="#" class="undogroup nav">Undo</a>'
                 ),
                 renderData: {},
                 renderSelectors: {
@@ -370,7 +370,7 @@ Ext.define('Connector.view.GroupSummaryBody', {
                 hidden: true,
                 margin: '0 0 20 0',
                 renderTpl: new Ext.XTemplate(
-                    'This group has filters which can be applied as active ' + mabMsg + 'filters. <a href="#" onclick="return false;" class="applygroup nav">Apply</a>'
+                    'This group has filters which can be applied as active ' + mabMsg + 'filters. <a href="#" class="applygroup nav">Apply</a>'
                 ),
                 renderData: {},
                 renderSelectors: {

--- a/webapp/frontPage/js/modal.js
+++ b/webapp/frontPage/js/modal.js
@@ -86,7 +86,7 @@ define(['jquery', 'magnific', 'util'], function($, magnific, util) {
       self.dismiss();
       self.toggle();
       self.initLoginInfo();
-      self.bindEnterKey();
+      self.bindListeners();
       self.initAccountSurvey();
       self.initPasswordGauge();
     };
@@ -134,7 +134,7 @@ define(['jquery', 'magnific', 'util'], function($, magnific, util) {
       }
     };
 
-    self.bindEnterKey = function()
+    self.bindListeners = function()
     {
       var $sign_in_container = self.$modal.find('[data-form=sign-in]');
       if ($sign_in_container.length > 0) {
@@ -153,6 +153,11 @@ define(['jquery', 'magnific', 'util'], function($, magnific, util) {
             e.preventDefault();
             $('#signinhelpsubmit').click();
           }
+        });
+
+        // click handler for registration page
+        $('#register-user-modal').click(function(){
+          reloadRegisterPage();
         });
       }
 
@@ -183,6 +188,11 @@ define(['jquery', 'magnific', 'util'], function($, magnific, util) {
             e.preventDefault();
             $('#registeraccountsubmit').click();
           }
+        });
+
+        // click handler for kaptcha
+        $('div.kaptcha').click(function(){
+          reloadRegisterPage();
         });
       }
     };
@@ -349,7 +359,7 @@ define(['jquery', 'magnific', 'util'], function($, magnific, util) {
                 // replace link that would take user to LabKey reset url
                 if (additionalMsg.indexOf('already associated with an account') > 0)
                     additionalMsg = 'The email address you have entered is already associated with an account.  If you have forgotten your password, you can ' +
-                        '<a class="register-links-error" onclick="return toggleRegistrationHelp();">reset your password</a>' +
+                        '<a class="register-links-error" href="#">reset your password</a>' +
                         '.  Otherwise, please contact your administrator.';
                 errorMsg = errorMsg + additionalMsg;
             }
@@ -358,6 +368,12 @@ define(['jquery', 'magnific', 'util'], function($, magnific, util) {
             }
           }
           $('.register-account-modal .modal .notifications p').html(errorMsg);
+
+          // register the click handler for password reset
+          $('a.register-links-error').click(function(){
+            toggleRegistrationHelp();
+          });
+
         });
       });
 


### PR DESCRIPTION
#### Rationale
Fixes for CSP violations: script tags missing `nonce` attribute and replacing inline javascript event handlers with a listener based approach.

The `onclick` handlers from `Frontpage.jsp` needed to be moved into `modal.js` into a new initializer function : `bindListeners` that gets called for each popup rendered by the magnific library.