### PR TITLE
Saved group fixes found by automated tests.

### DIFF
--- a/webapp/Connector/src/controller/Group.js
+++ b/webapp/Connector/src/controller/Group.js
@@ -698,9 +698,12 @@ Ext.define('Connector.controller.Group', {
         }
         this.loadDataTask.delay(300, undefined, this, [this.getGroupStore()]);
 
+        // this shouldn't be necessary, both stores referenced are now the same
+/*
         var editGroupView = this.getViewManager().getViewInstance('groupsave');
         if (editGroupView)
             editGroupView.refresh();
+*/
 
         this.clearFilter();
         this.hideGroupSaveBtns();

--- a/webapp/Connector/src/view/GroupSave.js
+++ b/webapp/Connector/src/view/GroupSave.js
@@ -775,7 +775,7 @@ Ext.define('Connector.view.GroupSave', {
             this.grouplist.getSelectionModel().deselectAll();
             this.grouplist.isMab = this.isMabGroup;
             var me = this;
-            this.grouplist.getStore().refreshData(function toggleSave() {
+    //        this.grouplist.getStore().refreshData(function toggleSave() {
                 me.grouplist.filterGroups();
                 var group = me.grouplist.getStore().getAt(0);
                 if (group)
@@ -788,7 +788,7 @@ Ext.define('Connector.view.GroupSave', {
                 {
                     me.getGroupUpdateSaveBtn().setDisabled(true);
                 }
-            }, me);
+    //        }, me);
         }
     },
 


### PR DESCRIPTION
#### Rationale
This fixes some client side errors associated with creating/editing/deleting CDS participant groups. I'm actively working in another branch around the same code and much of this code will eventually get deleted but for now this should get the tests passing.

The high level explanation is that at one point we had separate models and stores for the groups in the app depending if you were viewing them from the home page or the learn page. This is no longer true so we need to not try to refresh those stores more than necessary.