### PR TITLE
Move ext-patches out of ExtJS library folder

### DIFF
--- a/src/org/labkey/cds/view/template/ConnectorTemplate.jsp
+++ b/src/org/labkey/cds/view/template/ConnectorTemplate.jsp
@@ -101,7 +101,7 @@
         "/hopscotch/js/hopscotch.min.js",
 
         "/ext-4.2.1/ext-all" + (devMode ? "-debug" : "") + ".js",
-        "/ext-4.2.1/ext-patches.js",
+        "/ext-patches/ext4-patches.js",
         srcPath + "/ext-patches.js",
 
         // Client API Dependencies

--- a/src/org/labkey/cds/view/template/ConnectorTemplate.jsp
+++ b/src/org/labkey/cds/view/template/ConnectorTemplate.jsp
@@ -101,7 +101,7 @@
         "/hopscotch/js/hopscotch.min.js",
 
         "/ext-4.2.1/ext-all" + (devMode ? "-debug" : "") + ".js",
-        "/ext-patches/ext4-patches.js",
+        "/extPatches/ext4-patches.js",
         srcPath + "/ext-patches.js",
 
         // Client API Dependencies


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/platform/pull/5506 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5506

#### Changes
- Update path to `ext-patches.js` file.
