### PR TITLE
Consolidate curated group workflows

### DIFF
--- a/src/org/labkey/cds/view/template/ConnectorTemplate.jsp
+++ b/src/org/labkey/cds/view/template/ConnectorTemplate.jsp
@@ -247,6 +247,7 @@
             // Application Views
             srcPath + "/view/Selection.js",
             srcPath + "/view/DetailStatus.js",
+            srcPath + "/view/AbstractFilterStatus.js",
             srcPath + "/view/FilterStatus.js",
             srcPath + "/view/InfoPane.js",
             srcPath + "/view/GridPane.js",

--- a/test/src/org/labkey/test/components/cds/ActiveFilterDialog.java
+++ b/test/src/org/labkey/test/components/cds/ActiveFilterDialog.java
@@ -151,6 +151,7 @@ public class ActiveFilterDialog extends BaseCdsComponent<ActiveFilterDialog.Elem
         final Locator errorMsg = Locator.tagWithClass("div", "errormsg");
         Input groupName = new Input(Locator.name("groupname").findWhenNeeded(_activeFilterDialogEl), getDriver());
         Input groupDescription = new Input(Locator.textarea("groupdescription").findWhenNeeded(_activeFilterDialogEl), getDriver());
-        Checkbox sharedGroup = new Checkbox(Locator.xpath("//input[contains(@id,'creategroupshared')]").findWhenNeeded(getDriver()));
+        Checkbox sharedGroup = new Checkbox(Locator.xpath("//table[contains(@class, 'group-shared-checkbox')]/descendant::input[contains(@type, 'button')]")
+                .findWhenNeeded(getDriver()));
     }
 }

--- a/test/src/org/labkey/test/pages/cds/GroupDetailsPage.java
+++ b/test/src/org/labkey/test/pages/cds/GroupDetailsPage.java
@@ -70,7 +70,7 @@ public class GroupDetailsPage extends LabKeyPage<GroupDetailsPage.ElementCache>
     protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
         private final WebElement groupName = Locator.tagWithClass("div", "studyname").refindWhenNeeded(this);
-        private final WebElement groupDesc = Locator.tagWithId("table", "group-description-id").refindWhenNeeded(this);
+        private final WebElement groupDesc = Locator.tagWithClass("table", "group-description").refindWhenNeeded(this);
         private final Locator.XPathLocator groupModuleGrid = Locator.tagWithClassContaining("div", "groupslearnmodulegrid");
 
         private final WebElement editDetails = Locator.linkWithText("Edit details").findWhenNeeded(this);

--- a/test/src/org/labkey/test/pages/cds/MAbDataGrid.java
+++ b/test/src/org/labkey/test/pages/cds/MAbDataGrid.java
@@ -154,7 +154,7 @@ public class MAbDataGrid extends WebDriverComponent<MAbDataGrid.ElementCache>
 
     public void clearAllFilters()
     {
-        Optional<WebElement> clearAllFilterBtn = CDSHelper.Locators.cdsButtonLocator("clear", "mabfilterclear").findOptionalElement(getDriver());
+        Optional<WebElement> clearAllFilterBtn = CDSHelper.Locators.cdsButtonLocator("clear", "filter-clear-btn").findOptionalElement(getDriver());
         clearAllFilterBtn.ifPresent(webElement ->
                 elementCache().mabGrid.doAndWaitForRowUpdate(webElement::click));
         Locator.tagWithClass("div", "filtered-column").waitForElementToDisappear(this, WAIT_FOR_PAGE);

--- a/test/src/org/labkey/test/tests/cds/CDSGroupBaseTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSGroupBaseTest.java
@@ -67,9 +67,9 @@ public abstract class CDSGroupBaseTest extends CDSReadOnlyTest
         //Create a group.
         _composeGroup();
         //saveGroup verifies that the shared group checkbox is not present.
-        boolean result = cds.saveGroup(privateGroupOneName, PRIVATE_GROUP_NAME_DESCRIPTION[0], true, false, isMab());
+        boolean result = cds.saveGroup(privateGroupOneName, PRIVATE_GROUP_NAME_DESCRIPTION[0], true, false);
         assertFalse("Updating shared status of " + (isMab() ? "mab " : "") + "group should fail.", result);
-        result = cds.saveGroup(privateGroupOneName, PRIVATE_GROUP_NAME_DESCRIPTION[0], false, false, isMab());
+        result = cds.saveGroup(privateGroupOneName, PRIVATE_GROUP_NAME_DESCRIPTION[0], false, false);
         assertTrue("Failed to update " + (isMab() ? "mab " : "") + "group", result);
         cds.goToAppHome();
         cds.deleteGroupFromSummaryPage(privateGroupOneName);
@@ -77,7 +77,7 @@ public abstract class CDSGroupBaseTest extends CDSReadOnlyTest
 
         _impersonateRole("Editor");
         _composeGroup();
-        result = cds.saveGroup(privateGroupTwoName, PRIVATE_GROUP_NAME_DESCRIPTION[1], true, false, isMab());
+        result = cds.saveGroup(privateGroupTwoName, PRIVATE_GROUP_NAME_DESCRIPTION[1], true, false);
         assertTrue("Failed to create new shared " + (isMab() ? "mab " : "") + "group as Editor.", result);
         cds.goToAppHome();
         cds.deleteGroupFromSummaryPage(privateGroupTwoName);
@@ -111,7 +111,7 @@ public abstract class CDSGroupBaseTest extends CDSReadOnlyTest
         //As an editor, make a shared group and a private group
         _impersonateUser(NEW_USER_ACCOUNTS[0]);
         _composeGroup();
-        cds.saveGroup(privateGroupOneName, PRIVATE_GROUP_NAME_DESCRIPTION[0], false, false, isMab());
+        cds.saveGroup(privateGroupOneName, PRIVATE_GROUP_NAME_DESCRIPTION[0], false, false);
 
         // TODO: Fix/Update with the new Active filters workflow -- Use 'Edit group', update the group name with sharedGroupName, make it shared > Save menu > Update this group
 //        cds.saveGroup(sharedGroupName, "", true, false, isMab());

--- a/test/src/org/labkey/test/tests/cds/CDSGroupTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSGroupTest.java
@@ -228,7 +228,6 @@ public class CDSGroupTest extends CDSGroupBaseTest
 
         detailsPage.deleteGroup();
         cds.viewLearnAboutPage(LearnTab.GROUPS);
-        refresh();
         Assert.assertFalse("Deleted group is still present " + ASSAY_GROUP_NAME,
                 isElementPresent(Locator.tagWithText("h2", ASSAY_GROUP_NAME)));
     }
@@ -282,7 +281,6 @@ public class CDSGroupTest extends CDSGroupBaseTest
                 .saveGroup();
 
         log("Verifying Multi filter group");
-        refresh();
         cds.viewLearnAboutPage(LearnTab.GROUPS);
         click(Locator.tagWithText("h2", multiFilterGroup));
         detailsPage = new GroupDetailsPage(getDriver());

--- a/test/src/org/labkey/test/tests/cds/CDSMAbTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSMAbTest.java
@@ -959,37 +959,5 @@ public class CDSMAbTest extends CDSGroupBaseTest
         grid = new MAbDataGrid(this);
         Assert.assertTrue(MAB_COL + " should have been filtered", grid.isColumnFiltered(MAB_COL));
         Assert.assertFalse(STUDIES_COL + " should not have been filtered", grid.isColumnFiltered(STUDIES_COL));
-
-        // scenario no longer exists (replace an existing group)
-/*
-        log("Replace a mab group");
-        grid.clearAllFilters();
-        grid.setFacet(SPECIES_COL,false,"llama");
-        waitAndClick(CDSHelper.Locators.cdsButtonLocator("save", "mabfiltersave"));
-        waitAndClick(CDSHelper.Locators.cdsButtonLocator("replace an existing group"));
-
-        log("Verify mab filter can only replace existing mab groups");
-        Locator.XPathLocator listGroup = Locator.tagWithClass("div", "save-label");
-        waitForElement(listGroup.withText(mabPrivateGroup));
-        waitForElement(listGroup.withText(mabPublicGroup));
-        Locator badList = listGroup.withText(subjectPublicGroup);
-        Assert.assertFalse("Subject fitler shouldn't be listed for mab replace", isElementPresent(badList));
-        waitAndClick(listGroup.withText(mabPublicGroup));
-        click(CDSHelper.Locators.cdsButtonLocator("Save", "groupupdatesave"));
-
-        log("Verify replaced mab group");
-        grid.clearAllFilters();
-        cds.goToAppHome();
-        sleep(2000);
-        click(CDSHelper.Locators.getSharedGroupLoc(mabPublicGroup));
-        sleep(2000);
-        CDSHelper.NavigationLink.MABGRID.makeNavigationSelection(this);
-        grid = new MAbDataGrid(this);
-
-        Assert.assertTrue(SPECIES_COL + " should have been filtered", grid.isColumnFiltered(SPECIES_COL));
-        Assert.assertFalse(MAB_COL + " should not have been filtered", grid.isColumnFiltered(MAB_COL));
-        Assert.assertFalse(STUDIES_COL + " should not have been filtered", grid.isColumnFiltered(STUDIES_COL));
-*/
     }
-
 }

--- a/test/src/org/labkey/test/tests/cds/CDSMAbTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSMAbTest.java
@@ -906,13 +906,13 @@ public class CDSMAbTest extends CDSGroupBaseTest
 
         log("Compose a shared and a private mab group");
         _composeGroup();
-        cds.saveGroup(mabPrivateGroup, null, false, true, true);
+        cds.saveGroup(mabPrivateGroup, null, false, true);
 
         CDSHelper.NavigationLink.MABGRID.makeNavigationSelection(this);
         MAbDataGrid grid = new MAbDataGrid(this);
         grid.clearAllFilters();
         grid.setFacet(MAB_COL,false,"2F5", "A14");
-        cds.saveGroup(mabPublicGroup, null, true, true, true);
+        cds.saveGroup(mabPublicGroup, null, true, true);
 
         log("Verify mAb and subject groups listing");
         cds.goToAppHome();

--- a/test/src/org/labkey/test/tests/cds/CDSMAbTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSMAbTest.java
@@ -545,6 +545,7 @@ public class CDSMAbTest extends CDSGroupBaseTest
         ip.clickClose();
 
         ip.clickMabStudiesCount();
+        CDSStudyTooltipTest.dismissTooltip(this);
         log("Check Studies list.");
 
         expectedHasDataInMAbGrid = new ArrayList<>();
@@ -638,6 +639,7 @@ public class CDSMAbTest extends CDSGroupBaseTest
         ip.clickClose();
 
         ip.clickMabStudiesCount();
+        CDSStudyTooltipTest.dismissTooltip(this);
         log("Check Studies list.");
 
         expectedHasDataInMAbGrid = new ArrayList<>();

--- a/test/src/org/labkey/test/tests/cds/CDSMAbTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSMAbTest.java
@@ -916,7 +916,6 @@ public class CDSMAbTest extends CDSGroupBaseTest
 
         log("Verify mAb and subject groups listing");
         cds.goToAppHome();
-        refresh(); //TODO: Newly saved groups should be available without refresh, this is a bug that needs to be fixed.
         waitForText("My saved groups and plots", "Curated groups and plots");
         if (isElementPresent(CDSHelper.Locators.getPrivateGroupLoc(subjectPrivateGroup)) &&
                 isElementPresent(CDSHelper.Locators.getSharedGroupLoc(mabPublicGroup)))
@@ -959,6 +958,8 @@ public class CDSMAbTest extends CDSGroupBaseTest
         Assert.assertTrue(MAB_COL + " should have been filtered", grid.isColumnFiltered(MAB_COL));
         Assert.assertFalse(STUDIES_COL + " should not have been filtered", grid.isColumnFiltered(STUDIES_COL));
 
+        // scenario no longer exists (replace an existing group)
+/*
         log("Replace a mab group");
         grid.clearAllFilters();
         grid.setFacet(SPECIES_COL,false,"llama");
@@ -986,6 +987,7 @@ public class CDSMAbTest extends CDSGroupBaseTest
         Assert.assertTrue(SPECIES_COL + " should have been filtered", grid.isColumnFiltered(SPECIES_COL));
         Assert.assertFalse(MAB_COL + " should not have been filtered", grid.isColumnFiltered(MAB_COL));
         Assert.assertFalse(STUDIES_COL + " should not have been filtered", grid.isColumnFiltered(STUDIES_COL));
+*/
     }
 
 }

--- a/test/src/org/labkey/test/tests/cds/CDSStudyTooltipTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSStudyTooltipTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.pages.cds.DataGrid;
 import org.labkey.test.pages.cds.LearnGrid;
 import org.labkey.test.pages.cds.LearnGrid.LearnTab;
@@ -133,13 +134,13 @@ public class CDSStudyTooltipTest extends CDSReadOnlyTest
                 .ifPresent(WebElement::click);
 
         // Move the mouse off of the element that shows the tool tip, and then wait for the tool tip to disappear.
-        dismissTooltip();
+        dismissTooltip(this);
     }
 
     private String triggerToolTip(WebElement el)
     {
         // Move the mouse to the top left corner of the page and make sure there are no popups visible.
-        dismissTooltip();
+        dismissTooltip(this);
 
         return waitFor(() -> {
             // Move the mouse over the element.
@@ -157,11 +158,11 @@ public class CDSStudyTooltipTest extends CDSReadOnlyTest
         }, 2_000);
     }
 
-    public void dismissTooltip()
+    public static void dismissTooltip(WebDriverWrapper webDriver)
     {
-        shortWait().withMessage("Failed to dismiss tooltip").until(wd -> {
-        mouseOver(Locator.xpath(CDSHelper.LOGO_IMG_XPATH));
-            WebElement bubble = Locator.css(".hopscotch-bubble").findWhenNeeded(getDriver());
+        webDriver.shortWait().withMessage("Failed to dismiss tooltip").until(wd -> {
+        webDriver.mouseOver(Locator.xpath(CDSHelper.LOGO_IMG_XPATH));
+            WebElement bubble = Locator.css(".hopscotch-bubble").findWhenNeeded(webDriver.getDriver());
             return !bubble.isDisplayed() || bubble.getLocation().getY() <= 0; // Hidden, non-existent, or in the corner will suffice
         });
     }

--- a/test/src/org/labkey/test/util/cds/CDSHelper.java
+++ b/test/src/org/labkey/test/util/cds/CDSHelper.java
@@ -840,35 +840,15 @@ public class CDSHelper
 
     public boolean saveGroup(String name, @Nullable String description, boolean shared, boolean skipWaitForBar)
     {
-        return saveGroup(name, description, shared, skipWaitForBar, false);
-    }
-
-    public boolean saveGroup(String name, @Nullable String description, boolean shared, boolean skipWaitForBar, boolean isMab)
-    {
-        if (isMab) {
-            _test.click(Locators.cdsButtonLocator("save", "mabfiltersave"));
-        }
-        else {
-            _test.click(Locator.tagWithId("a", "filter-save-as-group-btn-id"));
-        }
+        _test.click(Locator.tagWithId("a", "filter-save-as-group-btn-id"));
 
         if (_test.isElementPresent(Locators.cdsButtonLocator("create a new group")))
         {
             _test.click(Locators.cdsButtonLocator("create a new group"));
         }
 
-        if (isMab) {
-            Locator.linkWithText("replace an existing group").waitForElement(_test.getDriver(), CDS_WAIT);
-        }
-        else {
-            _test.waitForElement(Locator.name("groupname"));
-        }
-
-        Locator.XPathLocator shareGroupCheckbox = Locator.xpath("//input[contains(@id,'creategroupshared')]");
-
-        if (isMab) {
-            shareGroupCheckbox = Locator.xpath("//input[contains(@id,'mabcreategroupshared')]");
-        }
+        _test.waitForElement(Locator.name("groupname"));
+        Locator.XPathLocator shareGroupCheckbox = Locator.xpath("//table[contains(@class, 'group-shared-checkbox')]/descendant::input[contains(@type, 'button')]");
         if (shared)
         {
             if (_test.isElementVisible(shareGroupCheckbox))
@@ -883,22 +863,12 @@ public class CDSHelper
             }
         }
 
-        if (isMab) {
-            _test.setFormElement(Locator.name("mabgroupname"), name);
-            if (null != description)
-                _test.setFormElement(Locator.name("mabgroupdescription"), description);
-        }
-        else {
-            _test.setFormElement(Locator.name("groupname"), name);
-            if (null != description)
-                _test.setFormElement(Locator.name("groupdescription"), description);
-        }
+        _test.setFormElement(Locator.name("groupname"), name);
+        if (null != description)
+            _test.setFormElement(Locator.name("groupdescription"), description);
 
         String saveBtnLocatorName;
-        if (isMab)
-            saveBtnLocatorName = "Save";
-        else
-            saveBtnLocatorName = "Save group";
+        saveBtnLocatorName = "Save group";
 
         _test.sleep(1000);
         if (skipWaitForBar)
@@ -915,11 +885,7 @@ public class CDSHelper
 
         // verify group save messaging
         //ISSUE 19997
-        if (isMab)
-            _test.waitForElement(Locator.xpath("//div[contains(@class, 'x-window-swmsg')]//div[contains(text(), 'saved')]"));
-        else
-            _test.waitForElement(Locator.tagWithId("div", "savedgroupname-id").notHidden());
-
+        _test.waitForElement(Locator.tagWithClass("div", "savedgroup-label-container").notHidden());
         _test.log("Saving '" + name + "' group was success!");
 
         return true;

--- a/test/src/org/labkey/test/util/cds/CDSHelper.java
+++ b/test/src/org/labkey/test/util/cds/CDSHelper.java
@@ -840,32 +840,31 @@ public class CDSHelper
 
     public boolean saveGroup(String name, @Nullable String description, boolean shared, boolean skipWaitForBar)
     {
-        _test.click(Locator.tagWithId("a", "filter-save-as-group-btn-id"));
-
+        _test.click(Ext4Helper.Locators.ext4Button("Save as a group"));
         if (_test.isElementPresent(Locators.cdsButtonLocator("create a new group")))
         {
             _test.click(Locators.cdsButtonLocator("create a new group"));
         }
 
-        _test.waitForElement(Locator.name("groupname"));
-        Locator.XPathLocator shareGroupCheckbox = Locator.xpath("//table[contains(@class, 'group-shared-checkbox')]/descendant::input[contains(@type, 'button')]");
+        _test.waitForElement(Locator.name("groupname").notHidden());
+        Locator shareGroupCheckbox = Locator.xpath("//table[contains(@class, 'group-shared-checkbox')]/descendant::input[contains(@type, 'button')]").notHidden();
         if (shared)
         {
-            if (_test.isElementVisible(shareGroupCheckbox))
+            if (_test.isElementPresent(shareGroupCheckbox))
             {
-                _test._ext4Helper.checkCheckbox(shareGroupCheckbox);
+                _test.click(shareGroupCheckbox);
             }
             else
             {
                 //Expected failure. The user attempts to save, but does not have sufficient permissions.
-                _test.click(Locators.cdsButtonLocator("Cancel", "groupcancelcreate"));
+                _test.click(Locators.cdsButtonLocator("Cancel", "groupcancelcreate").notHidden());
                 return false;
             }
         }
 
-        _test.setFormElement(Locator.name("groupname"), name);
+        _test.setFormElement(Locator.name("groupname").notHidden(), name);
         if (null != description)
-            _test.setFormElement(Locator.name("groupdescription"), description);
+            _test.setFormElement(Locator.name("groupdescription").notHidden(), description);
 
         String saveBtnLocatorName;
         saveBtnLocatorName = "Save group";
@@ -873,12 +872,12 @@ public class CDSHelper
         _test.sleep(1000);
         if (skipWaitForBar)
         {
-            _test.click(Locators.cdsButtonLocator(saveBtnLocatorName, "groupcreatesave"));
+            _test.click(Locators.cdsButtonLocator(saveBtnLocatorName, "groupcreatesave").notHidden());
         }
         else
         {
             applyAndMaybeWaitForBars(aVoid -> {
-                _test.click(Locators.cdsButtonLocator(saveBtnLocatorName, "groupcreatesave"));
+                _test.click(Locators.cdsButtonLocator(saveBtnLocatorName, "groupcreatesave").notHidden());
                 return null;
             });
         }
@@ -1179,7 +1178,7 @@ public class CDSHelper
 
     public void clearFilters(boolean skipWaitForBar)
     {
-        final WebElement clearButton = _test.waitForElement(Locators.cdsButtonLocator("clear", "filter-clear-btn"));
+        final WebElement clearButton = _test.waitForElement(Locators.cdsButtonLocator("clear", "filter-clear-btn").notHidden());
 
         if (skipWaitForBar)
         {

--- a/theme/connector/panel/_FilterPanel.scss
+++ b/theme/connector/panel/_FilterPanel.scss
@@ -278,10 +278,11 @@ ul.indent li {
 .groupsave-cancel-save-btns {
 
   display: flex;
-  height: 24px;
+  height: 25px;
   justify-content: center;
   align-items: center;
   gap: 5px;
+  background: #ebebeb;
 
   .cancel-save-btns {
     width: 71px;
@@ -300,14 +301,13 @@ ul.indent li {
   color: #FFF !important;
   display: flex;
   width: 72px;
-  height: 25px;
+  height: 24px;
   justify-content: center;
   align-items: center;
 
   .x-btn-inner {
     color: #FFF !important;
     text-align: center;
-    height: 25px;
     font-size: 11px;
     font-style: normal;
     font-weight: 400;

--- a/webapp/Connector/extapp.lib.xml
+++ b/webapp/Connector/extapp.lib.xml
@@ -103,6 +103,7 @@
         <!-- Application Views -->
         <script path="Connector/src/view/DetailStatus.js"/>
         <script path="Connector/src/view/Selection.js"/>
+        <script path="Connector/src/view/AbstractFilterStatus.js"/>
         <script path="Connector/src/view/FilterStatus.js"/>
         <script path="Connector/src/view/InfoPane.js"/>
         <script path="Connector/src/view/GridPane.js"/>

--- a/webapp/Connector/src/app/view/Group.js
+++ b/webapp/Connector/src/app/view/Group.js
@@ -304,10 +304,16 @@ Ext.define('Connector.app.view.Group', {
 
         this.on('show', function(){
             if (this.reloadStoreOnShow){
-                //console.log('reloading group slice');
-                this.getStore().loadSlice();
-                this.renderLoadingMask();
-                this.reloadStoreOnShow = false;
+                if (!this.loadDataTask) {
+                    this.loadDataTask = new Ext.util.DelayedTask(function() {
+                        //console.log('reloading group slice');
+                        this.getStore().removeAll();
+                        this.getStore().loadSlice();
+                        this.renderLoadingMask();
+                        this.reloadStoreOnShow = false;
+                    });
+                }
+                this.loadDataTask.delay(300, undefined, this);
             }
         }, this);
 

--- a/webapp/Connector/src/controller/Group.js
+++ b/webapp/Connector/src/controller/Group.js
@@ -52,7 +52,7 @@ Ext.define('Connector.controller.Group', {
             click : this.onMabGroupSave
         });
 
-        this.control('#groupcreatesave', {
+        this.control('#groupcreatesave-cmp', {
             click : this.doGroupSave
         });
 
@@ -122,6 +122,8 @@ Ext.define('Connector.controller.Group', {
 
         if (xtype === 'groupsave') {
 
+            // this end point may no longer exist
+            console.log('createView -> groupSummary');
             var state = Connector.getState();
 
             v = Ext.create('Connector.view.GroupSave', {
@@ -213,7 +215,7 @@ Ext.define('Connector.controller.Group', {
 
     doGroupSave : function()
     {
-        var view = this.getViewManager().getViewInstance('filterstatus').items.getByKey('filterstatus-items-id').items.getByKey('groupsave-id');
+        var view = this.getGroupSave();
         this.doSubjectGroupSave(view);
     },
 
@@ -315,14 +317,13 @@ Ext.define('Connector.controller.Group', {
 
     saveFailure : function(response, isAlert) {
 
-        Ext.getCmp('savedgroupname-id').hide();
-        Ext.getCmp('editgroupbtn-id').hide();
-        Ext.getCmp('editgroupbtn-container-id').hide();
+        this.getSavedGroupName().hide();
+        this.getEditGroupBtn().hide();
 
         var json = response.responseText ? Ext.decode(response.responseText) : response;
 
         if (json.exception) {
-            var view = this.getViewManager().getViewInstance('filterstatus').items.getByKey('filterstatus-items-id').items.getByKey('groupsave-id');
+            var view = this.getGroupSave();
             if (json.exception.indexOf('There is already a category named') > -1 || json.exception.indexOf('There is already a group named') > -1 ||
                     json.exception.indexOf('duplicate key value violates') > -1) {
                 // custom error response for invalid name
@@ -349,7 +350,7 @@ Ext.define('Connector.controller.Group', {
     },
 
     hideGroupSavePanel : function() {
-        var grpSaveCmp = Ext.getCmp('groupsave-id');
+        var grpSaveCmp = this.getGroupSave();
         grpSaveCmp.hideError();
         grpSaveCmp.hide();
     },
@@ -359,8 +360,7 @@ Ext.define('Connector.controller.Group', {
     },
 
     displayEditBtn : function() {
-        Ext.getCmp('editgroupbtn-id').show();
-        Ext.getCmp('editgroupbtn-container-id').show();
+        this.getEditGroupBtn().show();
     },
 
     doSubjectGroupSave: function(view)
@@ -411,7 +411,7 @@ Ext.define('Connector.controller.Group', {
 
     // update the filter label after insert or update
     updateFilterLabel: function(label) {
-        var groupLabel = Ext.getCmp('savedgroupname-id');
+        var groupLabel = this.getSavedGroupName();
         if (groupLabel && groupLabel.items) {
             // find the record to update the group name
             let rec = this.getGroupStore().findRecord('label', label);
@@ -424,7 +424,7 @@ Ext.define('Connector.controller.Group', {
 
     doGroupEdit: function()
     {
-        var view = Ext.getCmp('groupsave-id');
+        var view = this.getGroupSave();
         this.doSubjectGroupEdit(view);
     },
 
@@ -436,7 +436,7 @@ Ext.define('Connector.controller.Group', {
             var grpStore = StoreCache.getStore('Connector.app.store.Group');
 
             //get the original group that is being edited
-            var originalGroupName = Ext.getCmp('savedgroupname-id').items.items[0].data.savedGroupName;
+            var originalGroupName = this.getSavedGroupName().items.items[0].data.savedGroupName;
             var groupItems = grpStore.query('label', originalGroupName).items;
             var group = undefined;
 
@@ -459,7 +459,7 @@ Ext.define('Connector.controller.Group', {
                     me.displayEditBtn();
 
                     //display group label
-                    var groupLabel = Ext.getCmp('savedgroupname-id');
+                    var groupLabel = me.getSavedGroupName();
                     groupLabel.items.get(0).update({savedGroupName: grp.label});
                     groupLabel.show();
 
@@ -605,8 +605,26 @@ Ext.define('Connector.controller.Group', {
         this.getViewManager().hideView('groupsave');
     },
 
+    getGroupSave : function() {
+        // use the xtype and itemId in the selector
+        var groupSave = Ext.ComponentQuery.query('groupsave#groupsave-cmp');
+        return Ext.ComponentQuery.query('groupsave#groupsave-cmp')[0];
+    },
+
+    getSavedGroupName : function() {
+        return Ext.ComponentQuery.query('container#savedgroupname-cmp')[0];
+    },
+
+    getEditGroupBtn : function() {
+        return Ext.ComponentQuery.query('container#editgroupbtn-cmp')[0];
+    },
+
+    getNewGroupCancelAndSaveGroupBtns : function() {
+        return Ext.ComponentQuery.query('toolbar#new-group-cancel-save-btns-cmp')[0];
+    },
+
     onGroupCancel : function() {
-        Ext.getCmp('groupsave-id').hide();
+        this.getGroupSave().hide();
         Ext.getCmp('filter-save-as-group-btn-id').show();
     },
 
@@ -623,6 +641,9 @@ Ext.define('Connector.controller.Group', {
         this.onGroupSave(cmp, event, true);
     },
 
+    /**
+     * Needs to be refactored out and the old views removed once mab groups use the new UI
+     */
     onGroupSave : function(cmp, event, isMab)
     {
         var isMabGroup = isMab || (cmp && cmp.group && cmp.group.get('type') === 'mab');
@@ -717,7 +738,7 @@ Ext.define('Connector.controller.Group', {
     },
 
     hideGroupLabel() {
-        Ext.getCmp('savedgroupname-id').hide();
+        this.getSavedGroupName().hide();
     },
 
     resetFilterStatusBackGroundColor() {
@@ -725,12 +746,11 @@ Ext.define('Connector.controller.Group', {
     },
 
     hideEditGroupBtn() {
-        Ext.getCmp('editgroupbtn-id').hide();
-        Ext.getCmp('editgroupbtn-container-id').hide(); // hide the container too, otherwise the height is not adjusted and it displays blank space
+        this.getEditGroupBtn().hide();
     },
 
     hideCancelAndSaveGroupBtns() {
-        Ext.getCmp('groupsave-cancel-save-btns-id').hide();
+        this.getNewGroupCancelAndSaveGroupBtns().hide();
     },
 
     clearFilter : function() {

--- a/webapp/Connector/src/controller/Group.js
+++ b/webapp/Connector/src/controller/Group.js
@@ -116,25 +116,7 @@ Ext.define('Connector.controller.Group', {
     createView : function(xtype, context) {
         var v; // the view instance to be created
 
-        if (xtype === 'groupsave') {
-
-            // this end point may no longer exist
-            console.log('createView -> groupSummary');
-            var state = Connector.getState();
-
-            v = Ext.create('Connector.view.GroupSave', {
-                hideSelectionWarning: state.hasSelections(),
-                isMabGroup: context ? context.isMabGroup : false
-            });
-
-            state.on('selectionchange', v.onSelectionChange, v);
-
-            this.application.on('groupsaved', this.onGroupSaved, this);
-            this.application.on('groupedit', this.onGroupEdit, this);
-            this.application.on('mabgroupsaved', this.onMabGroupSaved, this);
-            this.application.on('mabgroupedited', this.onMabGroupEdited, this);
-        }
-        else if (xtype === 'groupsummary') {
+        if (xtype === 'groupsummary') {
 
             v = Ext.create('Connector.view.GroupSummary', {
                 store : this.getGroupStore(),
@@ -564,47 +546,6 @@ Ext.define('Connector.controller.Group', {
         }
 
         this.getViewManager().changeView('mabgrid', 'mabdatagrid', [mabGroup]);
-    },
-
-    // delete after mab refactor
-    _groupEditSave : function(name, filters, applyFilters, isMab)
-    {
-        if (applyFilters === true)
-        {
-            Connector.getState().setFilters(filters);
-        }
-        this.getViewManager().hideView('groupsave');
-
-        var fsview = isMab ? this.getViewManager().getViewInstance('mabstatus') : this.getViewManager().getViewInstance('filterstatus');
-        if (isMab && fsview.ownerCt && fsview.ownerCt.isHidden()) // not on mab grid page
-            fsview = this.getViewManager().getViewInstance('filterstatus');
-
-        if (fsview)
-        {
-            fsview.showMessage('Group \"' + Ext.String.ellipsis(name, 15, true) + '\" saved.', true);
-        }
-    },
-
-    onGroupSaved : function(response, filters)
-    {
-        // shouldn't use category label, it doesn't get updated in the database properly after renames, but we will use it if group label is missing
-        var groupLabel = response.group ? response.group.label : response.category.label;
-        this._groupEditSave(groupLabel, filters, true);
-    },
-
-    onMabGroupSaved : function(groupLabel)
-    {
-        this._groupEditSave(groupLabel, null, false, true);
-    },
-
-    onGroupEdit : function(response)
-    {
-        this._groupEditSave(response.group.label);
-    },
-
-    onMabGroupEdited: function(groupLabel)
-    {
-        this._groupEditSave(groupLabel, null, false, true);
     },
 
     doSubjectGroupDelete : function(config) {

--- a/webapp/Connector/src/controller/Group.js
+++ b/webapp/Connector/src/controller/Group.js
@@ -266,7 +266,7 @@ Ext.define('Connector.controller.Group', {
                     this.updateFilterLabel(groupname, true);
                 }, this, {single : true});
 
-                this.getGroupStore().refreshData();
+                this.refreshGroupStore();
             };
 
             var editSuccess = function() {
@@ -279,7 +279,7 @@ Ext.define('Connector.controller.Group', {
                     this.updateFilterLabel(groupname, true);
                 }, this, {single : true});
 
-                this.getGroupStore().refreshData();
+                this.refreshGroupStore();
             };
 
             var queryConfig = {
@@ -383,7 +383,7 @@ Ext.define('Connector.controller.Group', {
                     me.getGroupStore().on('dataloaded', function(){
                         this.updateFilterLabel(group.category.label);
                     }, me, {single : true});
-                    me.getGroupStore().refreshData();
+                    me.refreshGroupStore();
                 };
 
                 Connector.model.Filter.doGroupSave({
@@ -466,7 +466,7 @@ Ext.define('Connector.controller.Group', {
                     me.getGroupStore().on('dataloaded', function(){
                         this.updateFilterLabel(grp.label);
                     }, me, {single : true});
-                    me.getGroupStore().refreshData();
+                    me.refreshGroupStore();
                 };
 
                 var editFailure = function (response)
@@ -619,16 +619,20 @@ Ext.define('Connector.controller.Group', {
     },
 
     onDeleteSuccess: function(isMab) {
-        if (!this.loadDataTask) {
-            this.loadDataTask = new Ext.util.DelayedTask(function(store) {
-                store.refreshData();
-            });
-        }
-        this.loadDataTask.delay(300, undefined, this, [this.getGroupStore()]);
+        this.refreshGroupStore();
         this.clearFilter();
         this.hideGroupSaveBtns(isMab);
 
         this.getViewManager().changeView('home');
+    },
+
+    refreshGroupStore : function() {
+        if (!this.loadDataTask) {
+            this.loadDataTask = new Ext.util.DelayedTask(function() {
+                this.getGroupStore().refreshData();
+            });
+        }
+        this.loadDataTask.delay(300, undefined, this);
     },
 
     hideGroupSaveBtns : function(isMab) {

--- a/webapp/Connector/src/controller/Group.js
+++ b/webapp/Connector/src/controller/Group.js
@@ -129,6 +129,13 @@ Ext.define('Connector.controller.Group', {
                 store: this.getGroupStore(),
                 groupId: context.groupId
             });
+
+            var vm = this.getViewManager();
+            vm.on('beforechangeview', function(controller, view, currentContext) {
+                if (currentContext.view === "mabgroupsummary") {
+                    Connector.getService('FilterStatus').activateContainer('filterstatuscontainer');
+                }
+            });
         }
 
         return v;

--- a/webapp/Connector/src/controller/Group.js
+++ b/webapp/Connector/src/controller/Group.js
@@ -56,7 +56,7 @@ Ext.define('Connector.controller.Group', {
             click : this.doGroupSave
         });
 
-        this.control('#mabgroupcreatesave', {
+        this.control('#mabgroupcreatesave-cmp', {
             click : this.doMabGroupSave
         });
 
@@ -209,7 +209,7 @@ Ext.define('Connector.controller.Group', {
     },
 
     doMabGroupSave: function () {
-        var view = this.getViewManager().getViewInstance('groupsave');
+        var view = this.getMabGroupSave();
         this.doMabGroupEdit(view, false);
     },
 
@@ -248,8 +248,7 @@ Ext.define('Connector.controller.Group', {
             }
             else {
                 var group, groupname, me = this;
-                if (isReplace)
-                {
+                if (isReplace) {
                     replaceFromGroup.set('description', values['mabgroupdescription']);
                     replaceFromGroup.set('shared', typeof values['mabgroupshared'] != "undefined");  // convert to boolean
 
@@ -264,15 +263,14 @@ Ext.define('Connector.controller.Group', {
                         Shared: replaceFromGroup.get('shared')
                     };
                 }
-                else
-                {
-                    groupname = values['mabgroupname'];
+                else {
+                    groupname = values['groupname'];
                     group = {
                         Label: groupname,
-                        Description: values['mabgroupdescription'],
+                        Description: values['groupdescription'],
                         Filters: this.toJsonMabFilters(state.getMabFilters()),
                         Type: 'mab',
-                        Shared: typeof values['mabgroupshared'] != "undefined"
+                        Shared: typeof values['groupshared'] != "undefined"
                     };
 
                     if (isEditMode) {
@@ -300,7 +298,7 @@ Ext.define('Connector.controller.Group', {
                     rows: [group],
                     scope: this,
                     success : isEditMode ? editSuccess : saveSuccess,
-                    failure: this.saveFailure
+                    failure: this.saveFailureMab
                 };
 
                 if (isEditMode || isReplace)
@@ -315,7 +313,11 @@ Ext.define('Connector.controller.Group', {
         return StoreCache.getStore('Connector.app.store.Group')
     },
 
-    saveFailure : function(response, isAlert) {
+    saveFailureMab : function(response, options) {
+        this.saveFailure(response, options,true);
+    },
+
+    saveFailure : function(response, options, isMab, isAlert) {
 
         this.getSavedGroupName().hide();
         this.getEditGroupBtn().hide();
@@ -323,7 +325,7 @@ Ext.define('Connector.controller.Group', {
         var json = response.responseText ? Ext.decode(response.responseText) : response;
 
         if (json.exception) {
-            var view = this.getGroupSave();
+            var view = isMab ? this.getMabGroupSave() : this.getGroupSave();
             if (json.exception.indexOf('There is already a category named') > -1 || json.exception.indexOf('There is already a group named') > -1 ||
                     json.exception.indexOf('duplicate key value violates') > -1) {
                 // custom error response for invalid name
@@ -345,8 +347,8 @@ Ext.define('Connector.controller.Group', {
         }
     },
 
-    saveFailureAlert: function(response) {
-        this.saveFailure(response, true);
+    saveFailureAlert: function(response, options) {
+        this.saveFailure(response, options, true, true);
     },
 
     hideGroupSavePanel : function() {
@@ -602,13 +604,17 @@ Ext.define('Connector.controller.Group', {
     },
 
     onMabGroupCancel : function() {
-        this.getViewManager().hideView('groupsave');
+        this.getMabGroupSave().hide();
+        Ext.ComponentQuery.query('button#mabsavegroup-cmp')[0].show();
     },
 
     getGroupSave : function() {
         // use the xtype and itemId in the selector
-        var groupSave = Ext.ComponentQuery.query('groupsave#groupsave-cmp');
         return Ext.ComponentQuery.query('groupsave#groupsave-cmp')[0];
+    },
+
+    getMabGroupSave : function() {
+        return Ext.ComponentQuery.query('groupsave#groupsave-mab-cmp')[0];
     },
 
     getSavedGroupName : function() {

--- a/webapp/Connector/src/view/AbstractFilterStatus.js
+++ b/webapp/Connector/src/view/AbstractFilterStatus.js
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2014-2024 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+Ext.define('Connector.view.AbstractFilterStatus', {
+    extend: 'Ext.panel.Panel',
+    mixins: {
+        undohelper: 'Connector.utility.InfoPaneUtil'
+    },
+
+    ui: 'custom',
+
+    groupSave: undefined,           // need to create group save component
+
+    mabGroup: false,                // represents a mab group
+
+    /**
+     * Displays the current group name being edited,
+     */
+    getSavedGroupName: function (controller) {
+        return {
+            xtype: 'container',
+            itemId: this.mabGroup ? 'savedmabgroupname-cmp' : 'savedgroupname-cmp',
+            ui: 'custom',
+            cls: 'savedgroup-label-container',
+            hidden: true,
+            layout: {
+                type: 'hbox'
+            },
+            items: [{
+                xtype: 'box',
+                cls: 'savedgroup-label',
+                id: 'savedgroup-label-id',
+                tpl: new Ext.XTemplate(
+                        '<h4>',
+                        '<a href="#group/' + controller + '/{groupId}">{savedGroupName:htmlEncode}</a>',
+                        '</h4>',
+                ),
+                data: {
+                    savedGroupName: '',
+                    groupId: undefined
+                }
+            }],
+        }
+    },
+
+    getEditGroupBtn : function() {
+
+        var me = this;
+        return {
+            xtype: 'container',
+            itemId: this.mabGroup ? 'editmabgroupbtn-cmp' : 'editgroupbtn-cmp',
+            ui: 'custom',
+            layout: {
+                type: 'hbox'
+            },
+            hidden : true,
+            cls: 'edit-group-btn-container',
+            style: 'margin-left: 140px; margin-right: auto; margin-top: 10px;',
+            items: [{
+                xtype: 'button',
+                text: 'Save as', //previously 'Edit group'
+                ui: 'rounded-inverted-accent-small',
+                cls: 'edit-group-btn',
+                handler: function() {
+                    me.fireEvent('edit-group', me);
+                }
+            }]
+        };
+    },
+
+    getGroupNameCmp : function() {
+        return Ext.ComponentQuery.query('textfield#groupname-cmp', this.groupSave)[0];
+    },
+
+    getGroupDescriptionCmp : function() {
+        return Ext.ComponentQuery.query('textareafield#groupdescription-cmp', this.groupSave)[0];
+    },
+
+    getGroupSharedCmp : function() {
+        return Ext.ComponentQuery.query('checkbox#groupshared-cmp', this.groupSave)[0];
+    },
+
+    getNewGroupCancelAndSaveGroupBtnsCmp : function() {
+        return Ext.ComponentQuery.query('toolbar#new-group-cancel-save-btns-cmp', this.groupSave)[0];
+    },
+
+    getExistingGroupCancelAndSaveGroupBtnsCmp : function() {
+        return Ext.ComponentQuery.query('toolbar#existing-group-cancel-save-btns-cmp', this.groupSave)[0];
+    },
+
+    getEditGroupBtnCmp : function() {
+        var filterContainer = this.getComponent('filter-container');
+        if (filterContainer) {
+            if (this.mabGroup)
+                return filterContainer.getComponent('editmabgroupbtn-cmp');
+            else
+                return filterContainer.getComponent('editgroupbtn-cmp');
+        }
+    },
+
+    getSavedGroupNameCmp : function() {
+        var filterContainer = this.getComponent('filter-container');
+        if (filterContainer) {
+            if (this.mabGroup)
+                return filterContainer.getComponent('savedmabgroupname-cmp');
+            else
+                return filterContainer.getComponent('savedgroupname-cmp');
+        }
+    },
+
+    hideGroupLabel() {
+        this.getSavedGroupNameCmp().hide();
+    },
+
+    hideGroupSavePanel() {
+        this.groupSave.hide();
+    },
+
+    showEditGroupBtn() {
+        this.getEditGroupBtnCmp().show();
+    },
+
+    hideEditGroupBtn() {
+        this.getEditGroupBtnCmp().hide();
+    },
+
+    hideCancelAndSaveGroupBtns() {
+        this.getNewGroupCancelAndSaveGroupBtnsCmp().hide();
+    },
+
+    showCancelAndSaveMenuBtns() {
+        this.getExistingGroupCancelAndSaveGroupBtnsCmp().show();
+    },
+
+    showSavedGroup : function(group) {
+        //display group label of a saved group
+        var groupNameCmp = this.getSavedGroupNameCmp();
+        var groupName = group.get('label');
+
+        groupNameCmp.items.get(0).update({ savedGroupName : groupName, groupId: this.mabGroup ? group.get('rowid') : group.get('id') });
+        groupNameCmp.show();
+
+        //set the group-save form values
+        this.getGroupNameCmp().setValue(groupName);
+        this.getGroupDescriptionCmp().setValue(group.get('description'));
+        this.getGroupSharedCmp().setValue(group.get('shared'));
+    }
+});

--- a/webapp/Connector/src/view/FilterStatus.js
+++ b/webapp/Connector/src/view/FilterStatus.js
@@ -201,7 +201,6 @@ Ext.define('Connector.view.FilterStatus', {
     getEmptyText : function() {
         if (!this.emptyText) {
             this.emptyText = Ext.create('Ext.Component', {
-                id: 'filterstatus-emptytext-id',
                 style: 'background-color: #fff;',
                 tpl: new Ext.XTemplate('<div class="emptytext">All subjects</div>'),
                 data: {}

--- a/webapp/Connector/src/view/GroupSave.js
+++ b/webapp/Connector/src/view/GroupSave.js
@@ -305,6 +305,7 @@ Ext.define('Connector.view.GroupSave', {
                         }, {
                             xtype: 'checkbox',
                             itemId: 'groupshared-cmp',
+                            cls: 'group-shared-checkbox',
                             name: 'groupshared',
                             boxLabel: 'Shared group',
                             checked: false,

--- a/webapp/Connector/src/view/GroupSave.js
+++ b/webapp/Connector/src/view/GroupSave.js
@@ -32,6 +32,7 @@ Ext.define('Connector.view.GroupSave', {
     maxRecordsHeight: 13,
 
     isMabGroup: false,
+    mabGroup: false,
 
     stores: ['FilterStatus', 'MabStatus'],
 
@@ -319,11 +320,11 @@ Ext.define('Connector.view.GroupSave', {
                         style: 'padding-top: 5px',
                         items: ['->', {
                             text: 'Cancel',
-                            itemId: 'groupcancel',
+                            itemId: me.mabGroup ? 'mabgroupcancel' : 'groupcancel',
                             cls: 'group-cancel-btn groupcancelcreate'
                         }, {
                             text: 'Save group',
-                            itemId: 'groupcreatesave-cmp',
+                            itemId: me.mabGroup ? 'mabgroupcreatesave-cmp' : 'groupcreatesave-cmp',
                             disabled: true,
                             cls: 'save-group-btn groupcreatesave' // tests
                         }]
@@ -871,7 +872,8 @@ Ext.define('Connector.view.GroupSave', {
     },
 
     getGroupSaveBtnCmp : function() {
-        return Ext.ComponentQuery.query('button#groupcreatesave-cmp', this.createGroup)[0];
+        var selector = this.mabGroup ? 'button#mabgroupcreatesave-cmp' : 'button#groupcreatesave-cmp';
+        return Ext.ComponentQuery.query(selector, this.createGroup)[0];
     },
 
     onWindowResize : function(width, height)

--- a/webapp/Connector/src/view/GroupSave.js
+++ b/webapp/Connector/src/view/GroupSave.js
@@ -31,7 +31,6 @@ Ext.define('Connector.view.GroupSave', {
 
     maxRecordsHeight: 13,
 
-    isMabGroup: false,
     mabGroup: false,
 
     stores: ['FilterStatus', 'MabStatus'],
@@ -42,312 +41,145 @@ Ext.define('Connector.view.GroupSave', {
             mode: Connector.view.GroupSave.modes.CREATE
         });
 
-        var borderOffset = 2;
-        this.listRecordHeight = 24; // number in 'px' for height of a record display
-        this.listMaxHeight = (this.listRecordHeight * this.maxRecordsHeight) + borderOffset;
-        this.listMinHeight = (this.listRecordHeight * this.minRecordsHeight) + borderOffset;
-
         this.callParent([config]);
     },
 
     initComponent : function()
     {
-        //TODO: New active filters workflow doesn't apply to Mab groups just yet, when we are ready to make Mab groups workflow similar to subject groups
-        // we can remove this check and combine the two.
-        // Notice this.isMabGroup check throughout this file.
-        if (this.isMabGroup) {
-            this.items = [{
-                xtype: 'container',
-                itemId: 'content',
-                style: 'margin: 10px; background-color: #fff; border: 1px solid lightgrey; padding: 10px',
-                anchor: '100%',
-                items: [
-                    this.getTitle(),
-                    {
-                        xtype: 'box',
-                        hidden: this.hideSelectionWarning,
-                        itemId: 'selectionwarning',
-                        autoEl: {
-                            tag: 'div',
-                            style: 'padding-top: 10px;',
-                            children: [{
-                                tag: 'img',
-                                src: LABKEY.contextPath + '/Connector/images/warn.png',
-                                height: '13px',
-                                width: '13px',
-                                style: 'vertical-align: middle; margin-right: 8px;'
-                            },{
-                                tag: 'span',
-                                html: 'Current Selection will be applied'
-                            }]
-                        }
-                    },
-                    {
-                        xtype: 'box',
-                        itemId: 'error',
-                        hidden: true,
-                        autoEl: {
-                            tag: 'div',
-                            cls: 'errormsg'
-                        }
-                    },
-                    this.getCreateGroup(),
-                    this.getEditGroup(),
-                    this.getReplaceGroup()
-                ]
-            }];
-            LABKEY.Security.getUserPermissions({
-                success: function (userPerms, resp)
+        this.items = [{
+            xtype: 'container',
+            itemId: 'content',
+            style: 'padding-top: 6px;background-color: $gray-7',
+            anchor: '100%',
+            items: [
                 {
-                    if(this.getIsEditorOrHigher(userPerms))
-                    {
-                        Ext.getCmp('mabcreategroupshared').show();
-                        Ext.getCmp('editgroupshared').show();
-                        Ext.getCmp('updategroupshared').show();
+                    xtype: 'box',
+                    itemId: 'error',
+                    hidden: true,
+                    autoEl: {
+                        tag: 'div',
+                        cls: 'errormsg'
                     }
                 },
-                scope: this
-            });
-        }
-        else {
-            this.items = [{
-                xtype: 'container',
-                itemId: 'content',
-                style: 'padding-top: 6px;background-color: $gray-7',
-                anchor: '100%',
-                items: [
-                    {
-                        xtype: 'box',
-                        itemId: 'error',
-                        hidden: true,
-                        autoEl: {
-                            tag: 'div',
-                            cls: 'errormsg'
-                        }
-                    },
-                    this.getCreateGroup(),
-                    this.getCancelSaveMenuBtns()
-                ]
-            }];
+                this.getCreateGroup(),
+                this.getCancelSaveMenuBtns()
+            ]
+        }];
 
-            LABKEY.Security.getUserPermissions({
-                success: function (userPerms, resp)
+        LABKEY.Security.getUserPermissions({
+            success: function (userPerms, resp)
+            {
+                if(this.getIsEditorOrHigher(userPerms))
                 {
-                    if(this.getIsEditorOrHigher(userPerms))
-                    {
-                        this.getGroupSharedCmp().show();
-                    }
-                },
-                scope: this
-            });
-        }
-
+                    this.getGroupSharedCmp().show();
+                }
+            },
+            scope: this
+        });
         this.callParent();
-
-        Ext.EventManager.onWindowResize(this.onWindowResize, this);
     },
 
     getTitle : function()
     {
-        if (this.isMabGroup) {
-            if (!this.title)
-            {
-                this.title = Ext.create('Ext.Component', {
-                    tpl: '<h2>{title:htmlEncode} group</h2>',
-                    data: {
-                        title: this.defaultTitle
-                    }
-                });
-            }
-        }
         return this.title;
     },
 
     getCreateGroup : function() {
 
-        if (this.isMabGroup) {
-            if (!this.createGroup) {
-                this.createGroup = Ext.create('Ext.Container', {
-                    hidden: this.mode !== Connector.view.GroupSave.modes.CREATE,
-                    activeMode: Connector.view.GroupSave.modes.CREATE,
-                    style: 'padding-top: 10px;',
-                    items: [{
-                        itemId: 'mabcreategroupform',
-                        xtype: 'form',
-                        ui: 'custom',
-                        width: '100%',
-                        defaults: {
-                            width: '100%'
-                        },
-                        items: [{
-                            xtype: 'textfield',
-                            itemId: 'mabgroupname',
-                            name: 'mabgroupname',
-                            emptyText: 'Enter a group name',
-                            height: 30,
-                            allowBlank: false,
-                            validateOnBlur: false,
-                            maxLength: 100
-                        },{
-                            xtype: 'textareafield',
-                            id: 'mabcreategroupdescription',
-                            name: 'mabgroupdescription',
-                            emptyText: 'Group description',
-                            maxLength: 200
-                        },{
-                            xtype: 'checkbox',
-                            id: 'mabcreategroupshared',
-                            itemId: 'mabgroupshared',
-                            name: 'mabgroupshared',
-                            fieldLabel: 'Shared group',
-                            checked: false,
-                            hidden: true
-                        }]
-                    },{
-                        xtype: 'box',
-                        autoEl: {
-                            tag: 'div',
-                            style: 'margin-top: 15px;',
-                            html: 'Or...'
-                        }
-                    },{
-                        xtype: 'button',
-                        itemId: 'replace-grp-button',
-                        style: 'margin-top: 15px;',
-                        ui: 'linked-ul',
-                        text: 'replace an existing group',
-                        handler: function() { this.changeMode(Connector.view.GroupSave.modes.REPLACE); },
-                        scope: this
-                    },{
-                        xtype: 'toolbar',
-                        dock: 'bottom',
-                        ui: 'lightfooter',
-                        style: 'padding-top: 60px',
-                        items: ['->',{
-                            text: 'Cancel',
-                            itemId: 'mabgroupcancel',
-                            cls: 'groupcancelcreate mabgroupcancel' // tests
-                        },{
-                            text: 'Save',
-                            itemId: 'mabgroupcreatesave',
-                            cls: 'groupcreatesave mabgroupcreatesave' // tests
-                        }]
-                    }],
-                    listeners : {
-                        afterrender : {
-                            fn: function(c) {
-                                c.getComponent('mabcreategroupform').getComponent('mabgroupname').focus(false, true);
-                            },
-                            single: true,
-                            scope: this
-                        },
-                        show : {
-                            fn: function(c) {
-                                c.getComponent('mabcreategroupform').getComponent('mabgroupname').focus(false, true);
-                            },
-                            scope: this
-                        }
+        if (!this.createGroup) {
+            var me = this;
+            this.createGroup = Ext.create('Ext.Container', {
+                hidden: this.mode !== Connector.view.GroupSave.modes.CREATE,
+                activeMode: Connector.view.GroupSave.modes.CREATE,
+                cls: 'groupsave-panel-container',
+                itemId: 'create-group-container',
+                items: [{
+                    itemId: 'creategroupform',
+                    xtype: 'form',
+                    cls: 'groupsave-panel-form',
+                    ui: 'custom',
+                    width: '100%',
+                    defaults: {
+                        width: '100%'
                     },
-                    scope: this
-                });
-            }
-        }
-        else {
-            if (!this.createGroup) {
-                var me = this;
-                this.createGroup = Ext.create('Ext.Container', {
-                    hidden: this.mode !== Connector.view.GroupSave.modes.CREATE,
-                    activeMode: Connector.view.GroupSave.modes.CREATE,
-                    cls: 'groupsave-panel-container',
-                    itemId: 'create-group-container',
                     items: [{
-                        itemId: 'creategroupform',
-                        xtype: 'form',
-                        cls: 'groupsave-panel-form',
-                        ui: 'custom',
-                        width: '100%',
-                        defaults: {
-                            width: '100%'
-                        },
-                        items: [{
-                            xtype: 'textfield',
-                            cls: 'group-name-input',
-                            itemId: 'groupname-cmp',
-                            name: 'groupname',
-                            emptyText: 'Enter a group name',
-                            height: 30,
-                            allowBlank: false,
-                            validateOnBlur: false,
-                            maxLength: 100,
-                            listeners: {
-                                //dynamic enable/disable of save button based on the presence of text in the group name field
-                                change: function (field, newValue, oldValue) {
+                        xtype: 'textfield',
+                        cls: 'group-name-input',
+                        itemId: 'groupname-cmp',
+                        name: 'groupname',
+                        emptyText: 'Enter a group name',
+                        height: 30,
+                        allowBlank: false,
+                        validateOnBlur: false,
+                        maxLength: 100,
+                        listeners: {
+                            //dynamic enable/disable of save button based on the presence of text in the group name field
+                            change: function (field, newValue, oldValue) {
 
-                                    var saveBtn = me.getGroupSaveBtnCmp();
+                                var saveBtn = me.getGroupSaveBtnCmp();
 
-                                    //disable if undefined, null, or an empty string
-                                    if (Ext.isEmpty(newValue) || newValue.trim() === '') {
-                                        saveBtn.disable();
-                                    } else {
-                                        saveBtn.enable();
-                                    }
+                                //disable if undefined, null, or an empty string
+                                if (Ext.isEmpty(newValue) || newValue.trim() === '') {
+                                    saveBtn.disable();
+                                } else {
+                                    saveBtn.enable();
                                 }
                             }
-                        }, {
-                            xtype: 'textareafield',
-                            cls: 'group-description-input',
-                            itemId: 'groupdescription-cmp',
-                            name: 'groupdescription',
-                            emptyText: 'Group description',
-                            maxLength: 200,
-                            fieldLabel: 'Description',
-                            labelAlign: 'top'
-                        }, {
-                            xtype: 'checkbox',
-                            itemId: 'groupshared-cmp',
-                            cls: 'group-shared-checkbox',
-                            name: 'groupshared',
-                            boxLabel: 'Shared group',
-                            checked: false,
-                            hidden: true
-                        }]
-                    }, {
-                        // cancel and save buttons for a new group
-                        xtype: 'toolbar',
-                        itemId: 'new-group-cancel-save-btns-cmp',
-                        cls: 'groupsave-cancel-save-btns cancel-save-group-btns',
-                        dock: 'bottom',
-                        ui: 'lightfooter',
-                        style: 'padding-top: 5px',
-                        items: ['->', {
-                            text: 'Cancel',
-                            itemId: me.mabGroup ? 'mabgroupcancel' : 'groupcancel',
-                            cls: 'group-cancel-btn groupcancelcreate'
-                        }, {
-                            text: 'Save group',
-                            itemId: me.mabGroup ? 'mabgroupcreatesave-cmp' : 'groupcreatesave-cmp',
-                            disabled: true,
-                            cls: 'save-group-btn groupcreatesave' // tests
-                        }]
-                    }],
-                    listeners: {
-                        afterrender: {
-                            fn: function (c) {
-                                c.getComponent('creategroupform').getComponent('groupname-cmp').focus(false, true);
-                            },
-                            single: true,
-                            scope: this
-                        },
-                        show: {
-                            fn: function (c) {
-                                c.getComponent('creategroupform').getComponent('groupname-cmp').focus(false, true);
-                            },
-                            scope: this
                         }
+                    }, {
+                        xtype: 'textareafield',
+                        cls: 'group-description-input',
+                        itemId: 'groupdescription-cmp',
+                        name: 'groupdescription',
+                        emptyText: 'Group description',
+                        maxLength: 200,
+                        fieldLabel: 'Description',
+                        labelAlign: 'top'
+                    }, {
+                        xtype: 'checkbox',
+                        itemId: 'groupshared-cmp',
+                        cls: 'group-shared-checkbox',
+                        name: 'groupshared',
+                        boxLabel: 'Shared group',
+                        checked: false,
+                        hidden: true
+                    }]
+                }, {
+                    // cancel and save buttons for a new group
+                    xtype: 'toolbar',
+                    itemId: 'new-group-cancel-save-btns-cmp',
+                    cls: 'groupsave-cancel-save-btns cancel-save-group-btns',
+                    dock: 'bottom',
+                    ui: 'lightfooter',
+                    style: 'padding-top: 5px',
+                    items: ['->', {
+                        text: 'Cancel',
+                        itemId: me.mabGroup ? 'mabgroupcancel' : 'groupcancel',
+                        cls: 'group-cancel-btn groupcancelcreate'
+                    }, {
+                        text: 'Save group',
+                        itemId: me.mabGroup ? 'mabgroupcreatesave-cmp' : 'groupcreatesave-cmp',
+                        disabled: true,
+                        cls: 'save-group-btn groupcreatesave' // tests
+                    }]
+                }],
+                listeners: {
+                    afterrender: {
+                        fn: function (c) {
+                            c.getComponent('creategroupform').getComponent('groupname-cmp').focus(false, true);
+                        },
+                        single: true,
+                        scope: this
                     },
-                    scope: this
-                }, this);
-            }
+                    show: {
+                        fn: function (c) {
+                            c.getComponent('creategroupform').getComponent('groupname-cmp').focus(false, true);
+                        },
+                        scope: this
+                    }
+                },
+                scope: this
+            }, this);
         }
         return this.createGroup;
     },
@@ -381,281 +213,6 @@ Ext.define('Connector.view.GroupSave', {
         };
     },
 
-    getEditGroup : function()
-    {
-        if (!this._editGroup)
-        {
-            var editForm = Ext.create('Ext.Container', {
-                hidden: this.mode !== Connector.view.GroupSave.modes.EDIT,
-                activeMode: Connector.view.GroupSave.modes.EDIT,
-                title: 'Edit',
-                style: 'padding-top: 10px;',
-                items: [{
-                    itemId: 'mabcreategroupform',
-                    xtype: 'form',
-                    ui: 'custom',
-                    width: '100%',
-                    style: 'padding-top: 10px;',
-                    defaults: {
-                        width: '100%'
-                    },
-                    flex: 1,
-                    items: [{
-                        xtype: 'textfield',
-                        itemId: 'mabgroupname',
-                        name: 'mabgroupname',
-                        emptyText: 'Enter a group name',
-                        height: 30,
-                        allowBlank: false,
-                        validateOnBlur: false,
-                        maxLength: 100
-                    },{
-                        xtype: 'box',
-                        autoEl: {
-                            tag: 'div',
-                            style: 'padding: 5px 0; font-family: Verdana, sans-serif; font-size: 10pt;',
-                            html: 'Description:'
-                        }
-                    },{
-                        xtype: 'textareafield',
-                        id: 'editgroupdescription',
-                        itemId: 'mabgroupdescription',
-                        name: 'mabgroupdescription',
-                        emptyText: 'No description provided',
-                        maxLength: 200
-                    },{
-                        xtype: 'checkbox',
-                        id: 'editgroupshared',
-                        itemId: 'mabgroupshared',
-                        name: 'mabgroupshared',
-                        fieldLabel: 'Shared group',
-                        checked: false,
-                        hidden: true
-                    },{
-                        xtype: 'hiddenfield',
-                        itemId: 'groupid',
-                        name: 'groupid'
-                    },{
-                        xtype: 'hiddenfield',
-                        itemId: 'groupcategoryid',
-                        name: 'groupcategoryid'
-                    },{
-                        xtype: 'hiddenfield',
-                        itemId: 'groupfilters',
-                        name: 'groupfilters'
-                    },{
-                        xtype: 'hiddenfield',
-                        itemId: 'groupparticipantids',
-                        name: 'groupparticipantids'
-                    }]},{
-                    xtype: 'toolbar',
-                    dock: 'bottom',
-                    ui: 'lightfooter',
-                    style: 'padding-top: 60px',
-                    items: ['->',{
-                        text: 'Cancel',
-                        itemId: 'mabgroupcancel',
-                        cls: 'groupcanceledit' // tests
-                    },{
-                        text: 'Save',
-                        itemId: 'groupeditsave',
-                        cls: 'groupeditsave' // tests
-                    }]
-                }],
-                getForm : function()
-                {
-                    return editForm.getComponent('mabcreategroupform');
-                },
-                listeners : {
-                    afterrender : {
-                        fn: function(c) {
-                            c.getComponent('mabcreategroupform').getComponent('mabgroupdescription').focus(false, true);
-                        },
-                        scope: this
-                    },
-                    show : {
-                        fn: function(c) {
-                            c.getComponent('mabcreategroupform').getComponent('mabgroupdescription').focus(false, true);
-                        },
-                        scope: this
-                    }
-                }
-            });
-
-            this._editGroup = editForm;
-        }
-
-        return this._editGroup;
-    },
-
-    getReplaceGroup : function() {
-
-        if (!this.replaceGroup) {
-            var replaceForm = Ext.create('Ext.Container', {
-                hidden: this.mode !== Connector.view.GroupSave.modes.REPLACE,
-                activeMode: Connector.view.GroupSave.modes.REPLACE,
-                style: 'padding-top: 10px;',
-                items: [{
-                    xtype: 'box',
-                    autoEl: {
-                        tag: 'div',
-                        style: 'padding: 5px 0; font-family: Verdana, sans-serif; font-size: 10pt;',
-                        html: 'My groups:'
-                    }
-                },{
-                    xtype: 'container',
-                    overflowY: 'auto',
-                    overflowX: 'hidden',
-                    minHeight: this.listMinHeight,
-                    maxHeight: this.listMaxHeight,
-                    style: 'border: 1px solid lightgrey;',
-                    items: [{
-                        xtype: 'groupsavelistview',
-                        listeners: {
-                            render: function(v)
-                            {
-                                this.grouplist = v;
-                            },
-                            select: function(sm, group)
-                            {
-                                this.setActive(group, replaceForm.getForm());
-                            },
-                            viewready: function(v)
-                            {
-                                var group = v.getStore().getAt(0);
-                                if (group)
-                                {
-                                    v.getSelectionModel().select(0);
-                                    this.setActive(group, replaceForm.getForm());
-                                }
-                                var bodyBox = Ext.getBody().getBox();
-                                this.onWindowResize(bodyBox.width, bodyBox.height);
-                            },
-                            scope: this
-                        },
-                        scope: this
-                    }]
-                },{
-                    itemId: 'mabcreategroupform',
-                    xtype: 'form',
-                    ui: 'custom',
-                    width: '100%',
-                    style: 'padding-top: 10px;',
-                    defaults: {
-                        width: '100%'
-                    },
-                    flex: 1,
-                    items: [{
-                        xtype: 'box',
-                        autoEl: {
-                            tag: 'div',
-                            style: 'padding: 5px 0; font-family: Verdana, sans-serif; font-size: 10pt;',
-                            html: 'Description:'
-                        }
-                    },{
-                        xtype: 'textareafield',
-                        id: 'updategroupdescription',
-                        itemId: 'mabgroupdescription',
-                        name: 'mabgroupdescription',
-                        emptyText: 'No description provided',
-                        maxLength: 200
-                    },{
-                        xtype: 'checkbox',
-                        id: 'updategroupshared',
-                        itemId: 'mabgroupshared',
-                        name: 'mabgroupshared',
-                        fieldLabel: 'Shared group',
-                        checked: false,
-                        hidden: true
-                    }]
-                },{
-                    xtype: 'box',
-                    autoEl: {
-                        tag: 'div',
-                        style: 'margin-top: 15px;',
-                        html: 'Or...'
-                    }
-                },{
-                    xtype: 'button',
-                    itemId: 'create-grp-button',
-                    style: 'margin-top: 15px;',
-                    ui: 'linked-ul',
-                    text: 'create a new group',
-                    handler: function() { this.changeMode(Connector.view.GroupSave.modes.CREATE); },
-                    scope: this
-                },{
-                    xtype: 'toolbar',
-                    dock: 'bottom',
-                    ui: 'lightfooter',
-                    style: 'padding-top: 60px',
-                    items: ['->',{
-                        text: 'Cancel',
-                        itemId: 'mabgroupcancel',
-                        cls: 'groupcancelreplace' // tests
-                    },this.getGroupUpdateSaveBtn()]
-                }],
-                getForm : function()
-                {
-                    return replaceForm.getComponent('mabcreategroupform');
-                },
-                listeners : {
-                    show: this.refresh,
-                    scope: this
-                },
-                scope: this
-            });
-
-            this.replaceGroup = replaceForm;
-        }
-
-        return this.replaceGroup;
-    },
-
-    getGroupUpdateSaveBtn : function()
-    {
-        if (!this.groupUpdateSaveBtn) {
-            this.groupUpdateSaveBtn = Ext.create('Ext.Button', {
-                text: 'Save',
-                itemId: 'groupupdatesave',
-                cls: 'groupupdatesave' // tests
-            });
-        }
-        return this.groupUpdateSaveBtn;
-    },
-
-    changeMode : function(mode)
-    {
-        this.mode = mode;
-        var content = this.getComponent('content');
-        if (content)
-        {
-            var cc = content.items.items;
-            for (var i=0; i < cc.length; i++)
-            {
-                if (Ext.isDefined(cc[i].activeMode))
-                {
-                    if (cc[i].activeMode === mode)
-                    {
-                        // update the title
-                        this.getTitle().update({
-                            title: cc[i].title || this.defaultTitle
-                        });
-
-                        // show/hide selection message
-                        this.getComponent('content').getComponent('selectionwarning').hide();
-
-                        cc[i].show();
-                    }
-                    else
-                    {
-                        cc[i].hide();
-                    }
-                }
-            }
-            this.hideError();
-        }
-    },
-
     getMode : function() {
         return this.mode;
     },
@@ -670,15 +227,6 @@ Ext.define('Connector.view.GroupSave', {
             return false;
     },
 
-    editGroup : function(group)
-    {
-        if (group)
-        {
-            this.changeMode(Connector.view.GroupSave.modes.EDIT);
-            this.setActive(group, this.getEditGroup().getForm());
-        }
-    },
-
     onSelectionChange : function(selections) {
         // update warning
         var sw = this.getComponent('content').getComponent('selectionwarning');
@@ -687,139 +235,15 @@ Ext.define('Connector.view.GroupSave', {
         }
     },
 
-    setActive : function(groupModel, form)
-    {
-        if (form)
-        {
-            var group = Connector.model.FilterGroup.fromCohortGroup(groupModel),
-                    _id = form.getComponent('groupid'),
-                    name = form.getComponent('mabgroupname'),
-                    description = form.getComponent('mabgroupdescription'),
-                    categoryId = form.getComponent('groupcategoryid'),
-                    shared = form.getComponent('mabgroupshared'),
-                    filters = form.getComponent('groupfilters'),
-                    participantIds = form.getComponent('groupparticipantids');
-
-            if (_id)
-            {
-                _id.setValue(group.get('id'));
-            }
-
-            if (name)
-            {
-                name.setValue(group.get('label'));
-            }
-
-            if (description)
-            {
-                description.setValue(group.get('description'));
-            }
-
-            if (categoryId)
-            {
-                categoryId.setValue(group.get('categoryId'));
-            }
-
-            if (shared)
-            {
-                shared.setValue(group.get('shared'));
-            }
-
-            if (filters)
-            {
-                filters.setValue(Ext.encode({
-                    isLive : true,
-                    filters : group.get('filters')
-                }));
-            }
-
-            if (participantIds)
-            {
-                participantIds.setValue(Ext.encode(group.get('participantIds')));
-            }
-        }
-    },
-
     getActiveForm : function()
     {
-        var active,
-            modes = Connector.view.GroupSave.modes,
-            mode = this.getMode();
-
-        if (mode === modes.CREATE)
-        {
-            active = this.getCreateGroup();
-        }
-        else if (mode === modes.EDIT)
-        {
-            active = this.getEditGroup();
-        }
-        else
-        {
-            active = this.getReplaceGroup();
-        }
-
-        if(this.isMabGroup)
-            return active.getComponent('mabcreategroupform');
-
-        return active.getComponent('creategroupform');
-    },
-
-    refresh : function()
-    {
-        if (this.grouplist)
-        {
-            this.grouplist.getSelectionModel().deselectAll();
-            this.grouplist.isMab = this.isMabGroup;
-            var me = this;
-            this.grouplist.getStore().refreshData(function toggleSave() {
-                me.grouplist.filterGroups();
-                var group = me.grouplist.getStore().getAt(0);
-                if (group)
-                {
-                    me.getGroupUpdateSaveBtn().setDisabled(false);
-                    me.grouplist.getSelectionModel().select(0);
-                    me.setActive(group, me.getReplaceGroup().getForm());
-                }
-                else
-                {
-                    me.getGroupUpdateSaveBtn().setDisabled(true);
-                }
-            }, me);
-        }
-    },
-
-    getSelectedGroup : function()
-    {
-        var grp;
-        if (this.grouplist)
-        {
-            var selections = this.grouplist.getSelectionModel().getSelection();
-            if (!Ext.isEmpty(selections))
-            {
-                grp = Connector.model.FilterGroup.fromCohortGroup(selections[0]);
-            }
-        }
-        return grp;
+        return this.getCreateGroup().getComponent('creategroupform');
     },
 
     clear : function() {
         var form = this.getCreateGroup().getComponent('creategroupform');
-
-        if(this.isMabGroup)
-            form = this.getCreateGroup().getComponent('mabcreategroupform');
-
-        if (form) {
+        if (form)
             form.getForm().reset();
-        }
-
-        form = this.getReplaceGroup().getComponent('creategroupform');
-        if (this.isMabGroup) {
-            form = this.getReplaceGroup().getComponent('mabcreategroupform');
-        }
-        if (form) {
-            form.getForm().reset();
-        }
     },
 
     reset : function() {
@@ -875,94 +299,5 @@ Ext.define('Connector.view.GroupSave', {
     getGroupSaveBtnCmp : function() {
         var selector = this.mabGroup ? 'button#mabgroupcreatesave-cmp' : 'button#groupcreatesave-cmp';
         return Ext.ComponentQuery.query(selector, this.createGroup)[0];
-    },
-
-    onWindowResize : function(width, height)
-    {
-        if (this.getMode() == Connector.view.GroupSave.modes.REPLACE)
-        {
-            var hdrHeight = 53,
-                    paddingOffset = 20, // [10, 0, 10, 0]
-                    trueHeight = height - hdrHeight - paddingOffset,
-                    contentHeight = this.getComponent('content').getBox().height,
-                    listHeight = this.grouplist.getBox().height,
-                    h = listHeight;
-
-            if (trueHeight < contentHeight)
-            {
-                h = listHeight - (contentHeight - trueHeight);
-            }
-            else
-            {
-                // window height allow for more space, see if group list can expand
-                var lh = this.grouplist.getStore().getCount() * this.listRecordHeight,
-                        maxHeight = Math.min(this.listMaxHeight, lh),
-                        diff = trueHeight - contentHeight;
-
-                h = Math.min(maxHeight, listHeight + diff);
-            }
-
-            this.grouplist.setHeight(h);
-        }
-    }
-});
-
-Ext.define('Connector.view.GroupSaveList', {
-
-    extend: 'Ext.view.View',
-
-    alias: 'widget.groupsavelistview',
-
-    trackOver: true,
-
-    emptyText: '<div><span class="empty-group-label x-form-field x-form-empty-field">No groups defined</span>',
-
-    overItemCls: 'save-label-over',
-
-    selectedItemCls: 'save-label-selected',
-
-    itemSelector: 'div.save-label',
-
-    tpl: new Ext.XTemplate(
-            '<tpl for=".">',
-            '<div class="save-label" title="{label:htmlEncode}">{label:htmlEncode}</div>',
-            '</tpl>'
-    ),
-
-    loadMask: false,
-
-    viewConfig: {
-        loadMask: false
-    },
-
-    isMab: false,
-
-    initComponent : function() {
-
-        this.store = this.cloneGroupStore(StoreCache.getStore('Connector.app.store.Group'));
-        this.filterGroups();
-        this.callParent();
-    },
-
-    filterGroups: function() {
-        var isMab = this.isMab;
-        this.store.filterBy(function(record) {
-            if (isMab)
-                return record.get('type') === 'mab';
-            else
-                return record.get('type') !== 'mab';
-        });
-    },
-
-    cloneGroupStore: function(source) {
-        var clone = Ext.create('Ext.data.Store', {
-            model : 'Connector.app.model.Group'
-        });
-        Ext.each(source.getRange(), function(record) {
-            clone.add(Ext.clone(record.copy()));
-        });
-        clone.refreshData = source.refreshData;
-
-        return clone;
     }
 });

--- a/webapp/Connector/src/view/GroupSummary.js
+++ b/webapp/Connector/src/view/GroupSummary.js
@@ -184,7 +184,7 @@ Ext.define('Connector.view.GroupSummaryBody', {
                 itemId: 'descDisplay',
                 margin: '0 0 20 0',
                 htmlEncode: true,
-                id: 'group-description-id',
+                cls: 'group-description',
                 value: this._getDescription(this.group)
             }]
         }];

--- a/webapp/Connector/src/view/GroupSummary.js
+++ b/webapp/Connector/src/view/GroupSummary.js
@@ -83,12 +83,6 @@ Ext.define('Connector.view.GroupSummary', {
             }],
             buttons: [{
                 xtype: 'button',
-                text: 'Edit details',
-                ui: 'linked',
-                itemId: 'editgroupdetails',
-                group: group
-            },{
-                xtype: 'button',
                 text: 'Delete',
                 ui: 'linked',
                 handler: this.onDelete,

--- a/webapp/Connector/src/view/MabStatus.js
+++ b/webapp/Connector/src/view/MabStatus.js
@@ -18,7 +18,9 @@ Ext.define('Connector.view.MabStatus', {
     initComponent : function() {
         this.items = [
             this.getHeader(),
-            this.getSubHeader()
+            this.getSubHeader(),
+            this.getSaveAsGroupBtn(),
+            this.getGroupSavePanel()
         ];
 
         this.callParent();
@@ -54,6 +56,42 @@ Ext.define('Connector.view.MabStatus', {
             subtitle: 'All mAbs',
             subcls: 'emptytext'
         }
+    },
+
+    getSaveAsGroupBtn : function() {
+        var me = this;
+        return {
+            xtype: 'container',
+            itemId: 'mabfilterSaveAsGroupBtn',
+            cls: 'filter-save-as-group-btn-container',
+            //id: 'filter-save-as-group-btn-container-id',
+            ui: 'custom',
+            hidden : true,
+            layout: {
+                type: 'hbox'
+            },
+            items: [{
+                xtype: 'button',
+                //id: 'filter-save-as-group-btn-id',
+                text: '<div>Save as a group</div>', // need to wrap in div to get the 'g' in 'group' to fully show up otherwise it is cut off in the bottom
+                ui: 'rounded-inverted-accent-small',
+                cls: 'filter-save-as-group-btn filter-hdr-btn',
+                itemId: 'mabsavegroup-cmp',
+                style: 'margin-left: 110px; margin-right: auto; margin-top: 10px;',
+                handler: function() {
+                    this.hide();
+                    me.showGroupSavePanel(true);
+                }
+            }]
+        };
+    },
+
+    showGroupSavePanel(resetForm) {
+        if(resetForm) {
+            this.groupSave.hideError();
+            this.groupSave.reset();
+        }
+        this.groupSave.show();
     },
 
     hasMabFilters: function() {
@@ -127,18 +165,32 @@ Ext.define('Connector.view.MabStatus', {
 
         var saveBtn = filterHeader.query('#savemabgroup')[0];
         var clrBtn = filterHeader.query('#clearmab')[0];
+        var saveGroupBtn = this.getComponent('mabfilterSaveAsGroupBtn');
 
         if (!this.hasMabFilters()) {
             saveBtn.hide();
             clrBtn.hide();
+            saveGroupBtn.hide();
         }
         else {
             saveBtn.show();
             clrBtn.show();
+            saveGroupBtn.show();
         }
     },
 
     clearMabFilters: function() {
         Connector.getState().clearMabFilters(false, true);
+    },
+
+    getGroupSavePanel : function() {
+        if (!this.groupSave) {
+            this.groupSave = Ext.create('Connector.view.GroupSave', {
+                hidden: true,
+                mabGroup : true,
+                itemId: 'groupsave-mab-cmp'
+            });
+        }
+        return this.groupSave;
     }
 });

--- a/webapp/Connector/src/view/MabStatus.js
+++ b/webapp/Connector/src/view/MabStatus.js
@@ -179,27 +179,27 @@ Ext.define('Connector.view.MabStatus', {
         subHeader.update(this.getSubHeaderData());
 
         var clrBtn = filterHeader.query('#clearmab')[0];
-        var saveGroupBtn = this.getSaveAsGroupBtnCmp();
+        var saveGroupBtnContainer = this.getSaveAsGroupBtnContainer();
+        var saveGroupBtnCmp = this.getSaveAsGroupBtnCmp();
         var savedGroupNameCmp = this.getSavedGroupNameCmp();
 
         if (!this.hasMabFilters()) {
-            //saveBtn.hide();
             clrBtn.hide();
-            saveGroupBtn.hide();
+            saveGroupBtnContainer.hide();
             savedGroupNameCmp.hide();
             this.hideEditGroupBtn();
         }
         else {
-            //saveBtn.show();
             clrBtn.show();
             this.getFilterContainerCmp().show();
-            saveGroupBtn.show();
+            saveGroupBtnContainer.show();
+            saveGroupBtnCmp.show();
 
             var savedGroup = this.getMabGroup();
             if (savedGroup) {
                 this.showSavedGroup(savedGroup);
                 this.showEditGroupBtn();
-                saveGroupBtn.hide();
+                saveGroupBtnContainer.hide();
             }
         }
     },
@@ -257,11 +257,15 @@ Ext.define('Connector.view.MabStatus', {
         this.getEditGroupBtnCmp().show();
     },
 
-    getSaveAsGroupBtnCmp : function() {
+    getSaveAsGroupBtnContainer : function() {
         var filterContainer = this.getComponent('filter-container');
         if (filterContainer) {
             return filterContainer.getComponent('mabfilterSaveAsGroupBtn');
         }
+    },
+
+    getSaveAsGroupBtnCmp : function() {
+        return Ext.ComponentQuery.query('button#mabsavegroup-cmp')[0];
     },
 
     getFilterContainerCmp : function () {


### PR DESCRIPTION
#### Rationale
The PR follows up on some earlier work to create/edit/manage groups by converting the previous MAb group workflows to use the new UI patterns:
![image](https://github.com/LabKey/cds/assets/5741543/04b744a0-d994-4da8-b172-0b00e00d9a32)

Most of this effort can be categorized into these areas:
- Share the component(s) that were recently built to manage groups. There are 2 classes that handle filters for MAbs and subject and participant groups : `mabStatus.js` and `filterStatus.js`. The `groupSave.js` view contains most of the code for managing groups.
  - Each of the filter classes would have it's own instance of the `groupsave` component. To make this work most of the element IDs needed to be converted to itemIDs. Note that only a single element ID can exist in the DOM without creating rendering issues but itemIDs are scoped a components element hierarchy and provide more flexibility and scalability. 
  - Refactor `mabStatus.js` and `filterStatus.js` to share a common base class and use a component query to find and manage elements.
- Update the group controller to handle the new components and update the various selector routes to handle the new identifiers.
- Remove obsolete code
  - Remove the edit link from the group details view, the delete link still exists.
  - Delete the code to manage the legacy group UI. This was largely present in the `groupsave` view and the `group` controller.
- Automated tests
  - Update, fix existing tests to use new selectors
  - Update the MAb group tests to use the new UI, remove code which relied on obsolete scenarios (replace existing group)
  - Removed hard-coded refreshes on the learn page, this is no longer needed. 