### PR TITLE
Use WritablePropertyMap

### DIFF
--- a/src/org/labkey/cds/CDSManager.java
+++ b/src/org/labkey/cds/CDSManager.java
@@ -24,6 +24,7 @@ import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.PropertyManager;
+import org.labkey.api.data.PropertyManager.WritablePropertyMap;
 import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
@@ -273,7 +274,7 @@ public class CDSManager
 
     public void setActiveUserProperties(User user, Container container, Map<String, String> properties)
     {
-        PropertyManager.PropertyMap activeUserProperties = PropertyManager.getWritableProperties(user, container, CDS_ACTIVE_USER, true);
+        WritablePropertyMap activeUserProperties = PropertyManager.getWritableProperties(user, container, CDS_ACTIVE_USER, true);
         activeUserProperties.putAll(properties);
         activeUserProperties.save();
     }


### PR DESCRIPTION
#### Rationale
Using `WritablePropertyMap` is now required to update and save properties 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5893