### PR TITLE
Add more test log files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ webapp/temp
 CDS.iml
 
 # test logs
-test/sampledata/dataspace/*.log
+test/sampledata/**/*.log
 
 # generated theme artifacts
 app/Connector/bootstrap.css


### PR DESCRIPTION
#### Rationale
There are more CDS test logs than are currently accounted for (`test/sampledata/dataspace/etlLogs`). CDS sampledata includes no `.log` files so we can safely ignore them all.

#### Related Pull Requests
* N/A

#### Changes
* Add more test log files to .gitignore
