### PR TITLE
Update dependencies for repository consolidation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,10 @@ plugins {
 
 dependencies
 {
-    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "apiJarFile")
-    BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:premiumModules:dataintegration", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: ":server:modules:premiumModules:dataintegration", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "study"), depProjectConfig: "published", depExtension: "module")
-    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:premiumModules:dataintegration", depProjectConfig: "published", depExtension: "module")
 }
 
 project.evaluationDependsOn(BuildUtils.getPlatformModuleProjectPath(project.gradle, "query"))


### PR DESCRIPTION
#### Rationale
Several modules are being moved into the `premiumModules` repository.

#### Related Pull Requests
* https://github.com/LabKey/premiumModules/pull/77

#### Changes
* Update dependencies on consolidated repositories