### PR TITLE
Test updates to run on firefox 128

### DIFF
--- a/test/src/org/labkey/test/tests/cds/CDSLearnAboutExportTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSLearnAboutExportTest.java
@@ -18,6 +18,8 @@ import org.labkey.test.pages.cds.LearnDetailsPage;
 import org.labkey.test.pages.cds.LearnGrid;
 import org.labkey.test.pages.cds.LearnGrid.LearnTab;
 import org.labkey.test.util.cds.CDSHelper;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -109,7 +111,8 @@ public class CDSLearnAboutExportTest extends CDSReadOnlyTest
         LearnGrid learnGrid = new LearnGrid(LearnTab.ANTIGENS, this);
         learnGrid.setSearch("HIV-1 D");
         assertEquals("Incorrect number of rows after antigen filter", 1, learnGrid.getRowCount());
-        File filteredData = clickExportExcel(LearnTab.ANTIGENS, null);
+        click(Locator.tagWithId("span", "learn-grid-export-button-id-btnIconEl"));
+        File filteredData = clickAndWaitForDownload(Locator.linkWithText("Excel (*.XLS)"));
         assertEquals("Antigen : Incorrect number of rows imported", 1, getRowCount(filteredData));
         assertEquals("Incorrect Antigen imported after filter", "HIV-1 D.99986.B12 [gx120.D7.avi]", getRowFromExcel(filteredData, 1).get(2)); //getting short name column data
 
@@ -117,7 +120,8 @@ public class CDSLearnAboutExportTest extends CDSReadOnlyTest
         learnGrid = cds.viewLearnAboutPage(LearnTab.STUDIES);
         learnGrid.setSearch("RED 1");
         assertEquals("Incorrect number of rows after study filter", 1, learnGrid.getRowCount());
-        filteredData = clickExportExcel(LearnTab.STUDIES, null);
+        click(Locator.tagWithId("span", "learn-grid-export-button-id-btnIconEl"));
+        filteredData = clickAndWaitForDownload(Locator.linkWithText("Excel (*.XLS)"));
         assertEquals("Incorrect number of rows imported", 1, getRowCount(filteredData));
         assertEquals("Incorrect study name", "RED 1", getRowFromExcel(filteredData, 1).get(2));
     }

--- a/test/src/org/labkey/test/tests/cds/CDSLearnAboutExportTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSLearnAboutExportTest.java
@@ -18,8 +18,6 @@ import org.labkey.test.pages.cds.LearnDetailsPage;
 import org.labkey.test.pages.cds.LearnGrid;
 import org.labkey.test.pages.cds.LearnGrid.LearnTab;
 import org.labkey.test.util.cds.CDSHelper;
-import org.openqa.selenium.support.ui.ExpectedCondition;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/test/src/org/labkey/test/tests/cds/CDSVisualizationPlotTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSVisualizationPlotTest.java
@@ -574,7 +574,7 @@ public class CDSVisualizationPlotTest extends CDSReadOnlyTest
         waitForText("Heatmap on");
 
         log("Validate that there are bin squares in the plot.");
-        int squareCount = getElementCount(Locator.css("svg g.layer a.vis-bin-square"));
+        int squareCount = Locator.tagWithClass("a","vis-bin vis-bin-square").findElements(getDriver()).size();
         assertTrue("Expected over 2000 bin squares found: " + squareCount, squareCount > 2000);
 
         cds.ensureNoFilter();


### PR DESCRIPTION
#### Rationale
A bunch tests started failing in firefox 128 
🔶[CDSVisualizationTest.verifyLogAndLinearScales](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_LabkeyPremiumTrunk_GitModules_CdsPostgres95/3261534?hideTestsFromDependencies=false&expandBuildTestsSection=true&hideProblemsFromDependencies=false&expandBuildChangesSection=true&expandBuildDeploymentsSection=true)
SVG did not look as expected
Firefox 128 caused this test failure

🔶[CDSPlotTimeTest.verifyDiscreteTimeVariables](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_LabkeyPremiumTrunk_GitModules_CdsPostgres95/3261534?hideTestsFromDependencies=false&expandBuildTestsSection=true&hideProblemsFromDependencies=false&expandBuildChangesSection=true&expandBuildDeploymentsSection=true)
SVG did not look as expected
Firefox 128 caused this test failure

🔶[CDSVisualizationPlotTest.verifyBinnedPlot](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_LabkeyPremiumTrunk_GitModules_CdsPostgres95/3261534?hideTestsFromDependencies=false&expandBuildTestsSection=true&hideProblemsFromDependencies=false&expandBuildChangesSection=true&expandBuildDeploymentsSection=true)
Expected over 2000 bin squares found: 1990
Firefox 128 caused this test failure

🔶[CDSLearnAboutExportTest.testExportExcelDownload](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_LabkeyPremiumTrunk_GitModules_CdsPostgres95/3261534?hideTestsFromDependencies=false&expandBuildTestsSection=true&hideProblemsFromDependencies=false&expandBuildChangesSection=true&expandBuildDeploymentsSection=true)
Incorrect number of rows imported expected:<1> but was:<2>
Firefox 128 caused this test failure


#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
