### PR TITLE
Remove SupportedDatabases property now that default is PostgreSQL-only

### DIFF
--- a/module.properties
+++ b/module.properties
@@ -1,4 +1,3 @@
 ModuleClass: org.labkey.cds.CDSModule
-SupportedDatabases: pgsql
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6067