### PR TITLE
Don't leave test on CDS page as non-primary user

### DIFF
--- a/test/src/org/labkey/test/tests/cds/CDSLoginTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSLoginTest.java
@@ -44,7 +44,6 @@ import static org.junit.Assert.assertEquals;
 public class CDSLoginTest extends CDSReadOnlyTest
 {
     private static final String CDS_LOGIN_TESTUSER = "user_passwordtest@cds.test";
-    private final CDSHelper cds = new CDSHelper(this);
 
     @Before
     public void preTest()
@@ -154,6 +153,8 @@ public class CDSLoginTest extends CDSReadOnlyTest
         changePasswordDialog.setReEnterPassword(strongPwd);
         changePasswordDialog.submit();
         waitFor(() -> getCurrentUser().equals(CDS_LOGIN_TESTUSER), "login failed for " + CDS_LOGIN_TESTUSER, defaultWaitForPage);
+
+        goToHome(); // 'ensureSignedInAsPrimaryTestUser' can be interrupted by CDS session timeout page
     }
 
     @Override

--- a/test/src/org/labkey/test/tests/cds/CDSReadOnlyTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSReadOnlyTest.java
@@ -52,7 +52,7 @@ public class CDSReadOnlyTest extends BaseWebDriverTest implements ReadOnlyTest, 
     @BeforeClass
     public static void doSetup() throws Exception
     {
-        CDSReadOnlyTest initTest = (CDSReadOnlyTest)getCurrentTest();
+        CDSReadOnlyTest initTest = getCurrentTest();
         if (initTest.needsSetup())
         {
             CDSInitializer _initializer = new CDSInitializer(initTest);

--- a/test/src/org/labkey/test/util/cds/CDSHelper.java
+++ b/test/src/org/labkey/test/util/cds/CDSHelper.java
@@ -29,6 +29,7 @@ import org.labkey.test.pages.cds.DataGrid;
 import org.labkey.test.pages.cds.GroupDetailsPage;
 import org.labkey.test.pages.cds.LearnGrid;
 import org.labkey.test.pages.cds.LearnGrid.LearnTab;
+import org.labkey.test.pages.reports.ScriptReportPage.StandardReportOption;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
@@ -2048,7 +2049,7 @@ public class CDSHelper
                 _test.setCodeEditorValue("script-report-editor", reportScript);
 
             if (shareReport)
-                rReportHelper.selectOption(RReportHelper.ReportOption.shareReport);
+                rReportHelper.selectOption(StandardReportOption.shareReport);
 
             _test.waitForElement(Locator.tagWithText("span", "Save"));
             rReportHelper.saveReport(reportName);

--- a/test/src/org/labkey/test/util/cds/CDSHelper.java
+++ b/test/src/org/labkey/test/util/cds/CDSHelper.java
@@ -30,6 +30,7 @@ import org.labkey.test.pages.cds.GroupDetailsPage;
 import org.labkey.test.pages.cds.LearnGrid;
 import org.labkey.test.pages.cds.LearnGrid.LearnTab;
 import org.labkey.test.util.ApiPermissionsHelper;
+import org.labkey.test.util.ArtifactCollector;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LabKeyExpectedConditions;
@@ -2026,8 +2027,17 @@ public class CDSHelper
         _test.beginAt(queryUrl);
         if (!skipViewData)
         {
-            _test.waitForElement(Locator.linkWithText("view data"));
-            _test.click(Locator.linkWithText("view data"));
+            try
+            {
+                _test.waitForElement(Locator.linkWithText("view data"));
+                _test.clickAndWait(Locator.linkWithText("view data"));
+            }
+            catch (NoSuchElementException threadDump)
+            {
+                // TODO: remove after debugging
+                ArtifactCollector.dumpThreads();
+                throw threadDump;
+            }
         }
 
         // Check to see if the report already exists. If it does, then just ignore this test.

--- a/test/src/org/labkey/test/util/cds/CDSHelper.java
+++ b/test/src/org/labkey/test/util/cds/CDSHelper.java
@@ -30,7 +30,6 @@ import org.labkey.test.pages.cds.GroupDetailsPage;
 import org.labkey.test.pages.cds.LearnGrid;
 import org.labkey.test.pages.cds.LearnGrid.LearnTab;
 import org.labkey.test.util.ApiPermissionsHelper;
-import org.labkey.test.util.ArtifactCollector;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LabKeyExpectedConditions;
@@ -2027,17 +2026,8 @@ public class CDSHelper
         _test.beginAt(queryUrl);
         if (!skipViewData)
         {
-            try
-            {
-                _test.waitForElement(Locator.linkWithText("view data"));
-                _test.clickAndWait(Locator.linkWithText("view data"));
-            }
-            catch (NoSuchElementException threadDump)
-            {
-                // TODO: remove after debugging
-                ArtifactCollector.dumpThreads();
-                throw threadDump;
-            }
+            _test.waitForElement(Locator.linkWithText("view data"));
+            _test.click(Locator.linkWithText("view data"));
         }
 
         // Check to see if the report already exists. If it does, then just ignore this test.


### PR DESCRIPTION
#### Rationale
`ensureSignedInAsPrimaryTestUser` might log out the current user via HTTP. This can cause the CDS app to auto-redirect to the CDS login page as the test is trying to navigate to the standard login page. `CDSLoginTest.testPasswordStrength` shouldn't leave off on a CDS page while logged in as a non-primary user. 

#### Related Pull Requests
* N/A

#### Changes
* Don't leave test on CDS page as non-primary user
