### PR TITLE
BCR data updates

### DIFF
--- a/resources/etls/LoadApplication.xml
+++ b/resources/etls/LoadApplication.xml
@@ -106,6 +106,15 @@
                 </settings>
             </taskref>
         </transform>
+        <transform id="PopulateBCRsequence" type="TaskrefTransformStep">
+            <taskref ref="org.labkey.cds.data.steps.PopulateDatasetTask">
+                <settings>
+                    <setting name="sourceSchema" value="cds"/>
+                    <setting name="sourceQuery" value="ds_bcr_sequence_study"/>
+                    <setting name="targetDataset" value="BCR_sequence" />
+                </settings>
+            </taskref>
+        </transform>
         <transform id="PopulateAssay" type="TaskrefTransformStep">
             <taskref ref="org.labkey.cds.data.steps.PopulateAssayTask">
             </taskref>

--- a/resources/queries/cds/ds_bcr_sequence_study.sql
+++ b/resources/queries/cds/ds_bcr_sequence_study.sql
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2015-2025 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+SELECT
+    subject_id AS participantid,
+    CAST(study_day AS DOUBLE) AS sequencenum,
+    study_day AS visit_day,
+    prot AS study_prot,
+    prot,
+    specimen_type,
+    bcr_study_seq_id,
+    lab_code,
+    seq_method,
+    assay_identifier,
+    plate,
+    well
+
+FROM cds.import_bcr_sequence_study

--- a/resources/schemas/cds.xml
+++ b/resources/schemas/cds.xml
@@ -2248,17 +2248,19 @@
             <column columnName="container"/>
         </columns>
     </table>
-    <table tableName="pab_sequence_study" tableDbType="TABLE">
+    <table tableName="import_bcr_sequence_study" tableDbType="TABLE">
         <columns>
             <column columnName="row_id"/>
             <column columnName="prot"/>
             <column columnName="subject_id"/>
             <column columnName="study_day"/>
             <column columnName="specimen_type"/>
-            <column columnName="pab_id"/>
+            <column columnName="bcr_study_seq_id"/>
             <column columnName="lab_code"/>
             <column columnName="seq_method"/>
             <column columnName="assay_identifier"/>
+            <column columnName="plate"/>
+            <column columnName="well"/>
             <column columnName="container"/>
         </columns>
     </table>

--- a/resources/schemas/cds.xml
+++ b/resources/schemas/cds.xml
@@ -2241,9 +2241,9 @@
             <column columnName="container"/>
         </columns>
     </table>
-    <table tableName="pab_sequence" tableDbType="TABLE">
+    <table tableName="bcr_sequence" tableDbType="TABLE">
         <columns>
-            <column columnName="pab_id"/>
+            <column columnName="bcr_study_seq_id"/>
             <column columnName="sequence_id"/>
             <column columnName="container"/>
         </columns>

--- a/resources/schemas/dbscripts/postgresql/cds-25.000-25.001.sql
+++ b/resources/schemas/dbscripts/postgresql/cds-25.000-25.001.sql
@@ -1,0 +1,12 @@
+-- drop constraints to cds.pab_sequence
+ALTER TABLE cds.pab_sequence DROP CONSTRAINT PK_pab_sequence;
+ALTER TABLE cds.pab_sequence DROP CONSTRAINT FK_pab_sequence_sequence_id;
+DROP INDEX IF EXISTS cds.IX_pab_sequence_sequence_id;
+
+ALTER TABLE cds.pab_sequence RENAME COLUMN pab_id TO bcr_study_seq_id;
+ALTER TABLE cds.pab_sequence RENAME TO bcr_sequence;
+
+-- re-add constraints
+ALTER TABLE cds.bcr_sequence ADD CONSTRAINT PK_bcr_sequence PRIMARY KEY (bcr_study_seq_id, sequence_id, container);
+ALTER TABLE cds.bcr_sequence ADD CONSTRAINT FK_bcr_sequence_sequence_id FOREIGN KEY (sequence_id) REFERENCES cds.sequence (sequence_id);
+CREATE INDEX IX_bcr_sequence_sequence_id ON cds.bcr_sequence(sequence_id);

--- a/resources/schemas/dbscripts/postgresql/cds-25.000-25.001.sql
+++ b/resources/schemas/dbscripts/postgresql/cds-25.000-25.001.sql
@@ -10,3 +10,10 @@ ALTER TABLE cds.pab_sequence RENAME TO bcr_sequence;
 ALTER TABLE cds.bcr_sequence ADD CONSTRAINT PK_bcr_sequence PRIMARY KEY (bcr_study_seq_id, sequence_id, container);
 ALTER TABLE cds.bcr_sequence ADD CONSTRAINT FK_bcr_sequence_sequence_id FOREIGN KEY (sequence_id) REFERENCES cds.sequence (sequence_id);
 CREATE INDEX IX_bcr_sequence_sequence_id ON cds.bcr_sequence(sequence_id);
+
+-- rename cds.pab_sequence_study
+ALTER TABLE cds.pab_sequence_study DROP CONSTRAINT UQ_prot_subject_study_specimen_pab;
+ALTER TABLE cds.pab_sequence_study RENAME COLUMN pab_id TO bcr_study_seq_id;
+ALTER TABLE cds.pab_sequence_study ADD COLUMN plate VARCHAR(100);
+ALTER TABLE cds.pab_sequence_study ADD COLUMN well VARCHAR(100);
+ALTER TABLE cds.pab_sequence_study RENAME TO import_bcr_sequence_study;

--- a/src/org/labkey/cds/CDSManager.java
+++ b/src/org/labkey/cds/CDSManager.java
@@ -220,7 +220,7 @@ public class CDSManager
                     "import_virus_metadata_all",
                     "import_assay_combined_antigen_metadata",
 
-                    "pab_sequence",
+                    "bcr_sequence",
                     "pab_sequence_study",
                     "antibody_structure",
                     "sequence_header",

--- a/src/org/labkey/cds/CDSManager.java
+++ b/src/org/labkey/cds/CDSManager.java
@@ -219,9 +219,9 @@ public class CDSManager
                     "import_virus_synonym",
                     "import_virus_metadata_all",
                     "import_assay_combined_antigen_metadata",
+                    "import_bcr_sequence_study",
 
                     "bcr_sequence",
-                    "pab_sequence_study",
                     "antibody_structure",
                     "sequence_header",
                     "sequence_germline",

--- a/src/org/labkey/cds/CDSModule.java
+++ b/src/org/labkey/cds/CDSModule.java
@@ -106,7 +106,7 @@ public class CDSModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 25.000;
+        return 25.001;
     }
 
     @Override

--- a/src/org/labkey/cds/data/steps/CDSImportTask.java
+++ b/src/org/labkey/cds/data/steps/CDSImportTask.java
@@ -32,7 +32,6 @@ public class CDSImportTask extends ImportTask
         new CDSImportCopyConfig("preferred_allele"),
         new CDSImportCopyConfig("antibody_class"),
         new CDSImportCopyConfig("bcr_sequence"),
-        new CDSImportCopyConfig("pab_sequence_study"),
 
             // Core Tables
         new CDSImportCopyConfig("import_Study", "Study"),
@@ -93,6 +92,7 @@ public class CDSImportTask extends ImportTask
         new CDSImportCopyConfig("import_BAMA", "AssayBAMA"),
         new CDSImportCopyConfig("import_NABMAb", "AssayNABMAb"),
         new CDSImportCopyConfig("import_PKMAb", "AssayPKMAb"),
+        new CDSImportCopyConfig("import_bcr_sequence_study", "bcr_sequence_study"),
 
         // Virus data
         new CDSImportCopyConfig("import_Virus_Metadata_All", "Virus_Metadata_All"),

--- a/src/org/labkey/cds/data/steps/CDSImportTask.java
+++ b/src/org/labkey/cds/data/steps/CDSImportTask.java
@@ -31,7 +31,7 @@ public class CDSImportTask extends ImportTask
         new CDSImportCopyConfig("sequence_germline"),
         new CDSImportCopyConfig("preferred_allele"),
         new CDSImportCopyConfig("antibody_class"),
-        new CDSImportCopyConfig("pab_sequence"),
+        new CDSImportCopyConfig("bcr_sequence"),
         new CDSImportCopyConfig("pab_sequence_study"),
 
             // Core Tables

--- a/test/sampledata/dataspace/MasterDataspace/study/datasets/datasets_manifest.xml
+++ b/test/sampledata/dataspace/MasterDataspace/study/datasets/datasets_manifest.xml
@@ -22,5 +22,8 @@
     <dataset name="PKMAb" id="5008" type="Standard">
       <tags/>
     </dataset>
+    <dataset name="BCR_Sequence" id="5009" type="Standard">
+      <tags/>
+    </dataset>
   </datasets>
 </datasets>

--- a/test/sampledata/dataspace/MasterDataspace/study/datasets/datasets_metadata.xml
+++ b/test/sampledata/dataspace/MasterDataspace/study/datasets/datasets_metadata.xml
@@ -1781,4 +1781,95 @@
     </columns>
     <tableTitle>PK MAb</tableTitle>
   </table>
+  <table tableName="BCR_Sequence" tableDbType="TABLE">
+    <description>Contains up to one row of BCR Sequence data for each Subject/VisitTime combination.</description>
+    <columns>
+      <column columnName="SubjectId">
+        <datatype>varchar</datatype>
+        <columnTitle>Subject Id</columnTitle>
+        <description>Unique ID assigned to a subject for a given study.</description>
+        <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+        <nullable>false</nullable>
+        <importAliases>
+          <importAlias>ptid</importAlias>
+        </importAliases>
+        <fk>
+          <fkDbSchema>study</fkDbSchema>
+          <fkTable>Subject</fkTable>
+          <fkColumnName>SubjectId</fkColumnName>
+        </fk>
+      </column>
+      <column columnName="SequenceNum">
+        <datatype>double</datatype>
+        <columnTitle>Sequence Num</columnTitle>
+        <propertyURI>http://cpas.labkey.com/Study#SequenceNum</propertyURI>
+        <nullable>false</nullable>
+        <importAliases>
+          <importAlias>visit</importAlias>
+          <importAlias>visitid</importAlias>
+        </importAliases>
+      </column>
+      <column columnName="date">
+        <datatype>timestamp</datatype>
+        <columnTitle>Date</columnTitle>
+        <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+      </column>
+      <column columnName="visit_day">
+        <datatype>integer</datatype>
+        <columnTitle>Visit Day</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#int</rangeURI>
+        <description>Target study day defined for a study visit. Study days are relative to Day 0, where Day 0 is typically defined as enrollment and/or first injection.</description>
+        <measure>false</measure>
+      </column>
+      <column columnName="third_key">
+        <datatype>integer</datatype>
+        <columnTitle>Third Key</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#int</rangeURI>
+        <isHidden>true</isHidden>
+        <isKeyField>true</isKeyField>
+        <isAutoInc>true</isAutoInc>
+      </column>
+      <column columnName="study_prot">
+        <datatype>varchar</datatype>
+        <columnTitle>Study Protocol</columnTitle>
+        <description>Study protocol</description>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+        <dimension>true</dimension>
+      </column>
+      <column columnName="specimen_type">
+        <datatype>varchar</datatype>
+        <columnTitle>Specimen type</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+        <dimension>true</dimension>
+      </column>
+      <column columnName="bcr_study_seq_id">
+        <datatype>varchar</datatype>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+      </column>
+      <column columnName="lab_code">
+        <datatype>varchar</datatype>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+      </column>
+      <column columnName="seq_method">
+        <datatype>varchar</datatype>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+      </column>
+      <column columnName="assay_identifier">
+        <datatype>varchar</datatype>
+        <columnTitle>Assay identifier</columnTitle>
+        <description>Name identifying assay</description>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+        <dimension>true</dimension>
+      </column>
+      <column columnName="plate">
+        <datatype>varchar</datatype>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+      </column>
+      <column columnName="well">
+        <datatype>varchar</datatype>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+      </column>
+    </columns>
+    <tableTitle>BCR Sequence</tableTitle>
+  </table>
 </tables>

--- a/test/sampledata/dataspace/cdsimport/bcr_sequence.csv
+++ b/test/sampledata/dataspace/cdsimport/bcr_sequence.csv
@@ -1,4 +1,4 @@
-sequence_id,pab_id
+sequence_id,bcr_study_seq_id
 cds_seq_1,pab_id-1
 cds_seq_1,pab_id-2
 cds_seq_10,pab_id-1

--- a/test/sampledata/dataspace/cdsimport/bcr_sequence_study.csv
+++ b/test/sampledata/dataspace/cdsimport/bcr_sequence_study.csv
@@ -1,4 +1,4 @@
-prot,subject_id,study_day,specimen_type,pab_id,lab_code,seq_method,assay_identifier
+prot,subject_id,study_day,specimen_type,bcr_study_seq_id,lab_code,seq_method,assay_identifier
 q2,q2-044,1,human,pab_id_1,LC1,NA,AI-1
 r1,r1-032,2,human,pab_id_2,LC2,NA,AI-1
 z101,z101-041,3,human,pab_id_3,LC3,NA,AI-1


### PR DESCRIPTION
#### Rationale
- Rename `pab_sequence` table to `bcr_sequence`
- Rename `pab_sequence.pab_id` to `bcr_study_seq_id`
- For the former `pab_sequence_study` table, the dataspace team needs row level security. To achieve this behavior we map the incoming data to a new dataset named `BCR_Sequence` using a similar workflow as the other existing dataset. When the application gets populated, rows from the data import are copied to the appropriate study folder using the value in the `prot` field. This is why they dataset metadata needs to be modified so the new dataset can be initialized during folder import.