### PR TITLE
update BCR sample data to not create new subject visit sequences

### DIFF
--- a/test/sampledata/dataspace/cdsimport/bcr_sequence_study.csv
+++ b/test/sampledata/dataspace/cdsimport/bcr_sequence_study.csv
@@ -1,4 +1,4 @@
 prot,subject_id,study_day,specimen_type,bcr_study_seq_id,lab_code,seq_method,assay_identifier
-q2,q2-044,1,human,pab_id_1,LC1,NA,AI-1
-r1,r1-032,2,human,pab_id_2,LC2,NA,AI-1
-z101,z101-041,3,human,pab_id_3,LC3,NA,AI-1
+q2,q2-044,0,human,pab_id_1,LC1,NA,AI-1
+q2,q2-009,98,human,pab_id_2,LC2,NA,AI-1
+z117,z117-047,182,human,pab_id_3,LC3,NA,AI-1


### PR DESCRIPTION
#### Rationale
The recent change to support BCR data began causing a failure in the `CDSGridTest.verfyGridExport` due to expected rows counts changing. After some investigation to verify it wasn't a product bug, instead of updating the test, I'm modifying the BCR sample data that gets imported into the study datasets to not create new combinations of protocol, visit, and subject.