### PR TITLE
Fix time zone related CDS test failures

### DIFF
--- a/test/src/org/labkey/test/tests/cds/CDSStaticBlogsOnPublicPageTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSStaticBlogsOnPublicPageTest.java
@@ -46,8 +46,13 @@ public class CDSStaticBlogsOnPublicPageTest extends CDSReadOnlyTest
         Assert.assertTrue("News section is missing", isElementPresent(Locator.tagWithText("h1", "News")));
         Assert.assertEquals("Incorrect number of thumbnails", 4,
                 Locator.tag("a").findElements(Locator.tagWithClass("tr", "thumbnail").findElement(getDriver())).size());
-        Assert.assertEquals("Incorrect blog publication dates", Arrays.asList("August 11, 2023", "July 25, 2023", "March 17, 2014", "January 28, 2014"),
-                getTexts(Locator.tag("td").findElements(Locator.tagWithClass("tr", "pub-date").findElement(getDriver()))));
+        boolean westOfServer = getRelativeTimeZoneOffset() < 0;
+        Assert.assertEquals("Incorrect blog publication dates", Arrays.asList(
+                "August %d, 2023".formatted(westOfServer ? 10 : 11),
+                "July %d, 2023".formatted(westOfServer ? 24 : 25),
+                "March %d, 2014".formatted(westOfServer ? 16 : 17),
+                "January %d, 2014".formatted(westOfServer ? 27 : 28)),
+            getTexts(Locator.tag("td").findElements(Locator.tagWithClass("tr", "pub-date").findElement(getDriver()))));
         Assert.assertEquals("Incorrect blog titles", Arrays.asList("Getting Started with Lab Inventory Tracking",
                         "What's New in LabKey 23.7", "Release: LabKey Server v14.1", "Article: MedCity covers the LabKey story: \"Open-sourced in Seattle\""),
                 getTexts(Locator.tag("td").findElements(Locator.tagWithClass("tr", "blog-title").findElement(getDriver()))));

--- a/test/src/org/labkey/test/tests/cds/CDSVisualizationTest.java
+++ b/test/src/org/labkey/test/tests/cds/CDSVisualizationTest.java
@@ -248,10 +248,9 @@ public class CDSVisualizationTest extends CDSReadOnlyTest
         xaxis.pickVariable(CDSHelper.DEMO_DATE_FUP_COMP);
         xaxis.confirmSelection();
 
-        // Special casing this test. for what ever reason sometimes it will have 3/13/2011 other times it will be 3/12/2011.
-        // Because this value appears to be calculated I will use regular expression to validate.
+        // Date ticks vary slightly based on time zone and when test is run
         log("Validating Followup Complete");
-        pattern = Pattern.compile("4/2[0-9]/20156/2[0-9]/20158/1[0-9]/201510/1[0-9]/201512/1[0-9]/201502468101214");
+        pattern = Pattern.compile("4/2[56]/20156/2[23]/20158/(19|20)/201510/1[56]/201512/1[23]/201502468101214");
         cds.assertPlotTickText(pattern);
 
         xaxis.openSelectorWindow();
@@ -260,7 +259,7 @@ public class CDSVisualizationTest extends CDSReadOnlyTest
 
         // Another special case scenario.
         log("Validating Date Made Public");
-        pattern = Pattern.compile("3/1[0-9]/20117/[1-9]/201110/3[0-1]/20112/2[0-9]/20126/1[0-9]/201210/1[0-9]/20122/[1-9]/20135/3[0-1]/201302468101214");
+        pattern = Pattern.compile("3/1[23]/20117/[67]/201110/3[01]/20112/2[34]/20126/1[78]/201210/1[12]/20122/[45]/20135/3[01]/201302468101214");
         cds.assertPlotTickText(pattern);
 
         xaxis.openSelectorWindow();
@@ -269,7 +268,7 @@ public class CDSVisualizationTest extends CDSReadOnlyTest
 
         // Another special case scenario.
         log("Validating Start Date");
-        pattern = Pattern.compile("11/[1-9]/20046/1[0-9]/20061/1[0-9]/20088/1[0-9]/20093/1[0-9]/201102468101214");
+        pattern = Pattern.compile("11/9/20046/1[01]/20061/1[01]/20088/11/20093/1[23]/201102468101214");
         cds.assertPlotTickText(pattern);
 
         xaxis.openSelectorWindow();

--- a/test/src/org/labkey/test/util/cds/CDSHelper.java
+++ b/test/src/org/labkey/test/util/cds/CDSHelper.java
@@ -16,6 +16,7 @@
 package org.labkey.test.util.cds;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.assertj.core.api.Assertions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
@@ -1496,7 +1497,7 @@ public class CDSHelper
     {
         // Firefox removes the \n when returning the text, so going to go to lowest common denominator (Firefox).
         String shownText = getPlotTickText(svgIndex);
-        Assert.assertTrue("SVG did not look as expected. Patter expected: " + p.pattern() + " Actual string: " + shownText, p.matcher(shownText).matches());
+        Assertions.assertThat(shownText).as("SVG tick text").matches(p);
     }
 
     public void assertPlotTickText(String expectedTickText)


### PR DESCRIPTION
#### Rationale
Some displayed dates can vary depending on the client time zone. Now that we are running tests with time zone shifting, the tests need to account for it.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/2258

#### Changes
* Fix time zone related test failures
